### PR TITLE
Helsinki audience

### DIFF
--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -71,7 +71,7 @@ class FormFields extends React.Component {
 
     render() {
         let helMainOptions = mapKeywordSetToForm(this.props.editor.keywordSets, 'helfi:topics')
-        let helTargetOptions = mapKeywordSetToForm(this.props.editor.keywordSets, 'helfi:audiences')
+        let helTargetOptions = mapKeywordSetToForm(this.props.editor.keywordSets, 'helsinki:audiences')
         let helEventLangOptions = mapLanguagesSetToForm(this.props.editor.languages)
 
         const { values, validationErrors, contentLanguages } = this.props.editor

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -84,7 +84,7 @@
     "sosiaali-ja-terveyspalvelut": "Sosiaali- ja terveyspalvelut",
     "kaupunki-ja-hallinto": "Kaupunki ja hallinto",
     "hel-keywords": "Avainsanat",
-    "hel-target-groups": "Hel.fi-kohderyhmät",
+    "hel-target-groups": "Kohderyhmät",
     "all": "Ei erityistä kohderyhmää",
     "yhdistykset": "Yhdistykset",
     "yrittajat": "Yrittäjät",

--- a/src/utils/formDataMapping.js
+++ b/src/utils/formDataMapping.js
@@ -11,6 +11,40 @@ export {
     mapAPIDataToUIFormat
 }
 
+// hel.fi audience keywords that correspond to YSO audience keywords need to be posted also for now
+
+const helFiYsoAudienceMapping = {
+    'helfi:1': ['yso:p4354', 'yso:p13050'],
+    'helfi:2': ['yso:p11617'],
+    'helfi:3': ['yso:p6165'],
+    'helfi:4': ['yso:p7179'],
+    'helfi:5': ['yso:p2434'],
+    'helfi:6': ['yso:p3128'],
+    'helfi:7': ['yso:p1393'],
+}
+
+function _addHelFiAudienceKeywords(original_audiences) {
+    let audiences = _.clone(original_audiences)
+
+    const audienceIds = _.map(audiences, function(audience) {
+        // parse keyword ID from keyword URL
+        return audience.slice(_.lastIndexOf(audience, '/', audience.length - 2) + 1, -1)
+    })
+
+    // iterate hel.fi keywords
+    _.forOwn(helFiYsoAudienceMapping, function(ysoIDs, helFiID) {
+
+        // check that every YSO keyword for the current hel.fi keyword is selected
+        const containsEveryYso = _.every(ysoIDs, function(ysoID) {
+            return _.contains(audienceIds, ysoID)
+        })
+        if (containsEveryYso) {
+            audiences.push(`${appSettings.api_base}/keyword/` + helFiID + '/')
+        }
+    })
+    return audiences
+}
+
 // TODO: Refactoring form components to output and accept the correct format (like <MultiLanguageField> to output {fi: name, se: namn})
 
 function mapUIDataToAPIFormat(values) {
@@ -60,7 +94,8 @@ function mapUIDataToAPIFormat(values) {
     }
 
     if(values.audience && values.audience.length !== undefined) {
-        obj.audience = _.map(values.audience, (item) => ({ '@id': item }))
+        const audiences = _addHelFiAudienceKeywords(values.audience)
+        obj.audience = _.map(audiences, (item) => ({ '@id': item }))
     }
 
     if(values.in_language) {


### PR DESCRIPTION
Target group keyword set is changed from `helfi:audiences` to `helsinki:audiences`. When posting an event to the backend, old hel.fi keywords that correspond to selected new keywords are posted also for now.