### PR TITLE
fixed build: changed sass imports

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -10,12 +10,14 @@
 @import "node_modules/bootstrap/scss/bootstrap-reboot.scss";
 @import "node_modules/bootstrap/scss/bootstrap-grid.scss";
 
+@import "node_modules/bootstrap/scss/mixins/_border-radius.scss";
 @import "node_modules/bootstrap/scss/_modal.scss";
 @import "node_modules/bootstrap/scss/mixins/_reset-text.scss";
-@import "node_modules/bootstrap/scss/mixins/_border-radius.scss";
 @import "node_modules/bootstrap/scss/_popover.scss";
-@import "node_modules/bootstrap/scss/mixins/_label.scss";
-@import "node_modules/bootstrap/scss/_labels.scss";
+@import "node_modules/bootstrap/scss/utilities/_display.scss";
+
+@import "node_modules/bootstrap/scss/mixins/_background-variant.scss";
+@import "node_modules/bootstrap/scss/utilities/_background.scss";
 
 // Define a custom sass file to override any variables defined in scaffolding.scss
 // @import "my-custom-overrides.scss";

--- a/src/components/FilterableEventTable/index.js
+++ b/src/components/FilterableEventTable/index.js
@@ -38,7 +38,7 @@ let EventRow = (props) => {
     let draftClass = draft ? 'draft-row' : ''
     let nameColumn = null
     if (draft) {
-        nameColumn = (<TableRowColumn className={draftClass}><span className="label label-warning">LUONNOS</span> <Link to={url}>{name}</Link></TableRowColumn>)
+        nameColumn = (<TableRowColumn className={draftClass}><div className="d-inline bg-danger draft-label">LUONNOS</div> <Link to={url}>{name}</Link></TableRowColumn>)
     }
     else {
         nameColumn = (<TableRowColumn><Link to={url}>{name}</Link></TableRowColumn>)

--- a/src/components/FilterableEventTable/index.scss
+++ b/src/components/FilterableEventTable/index.scss
@@ -1,3 +1,8 @@
 .draft-row {
     background-color: rgba(255, 208, 91, 0.60) !important;
 }
+
+.draft-label {
+    padding: 6px;
+    margin-right: 5px;
+}

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -21,9 +21,9 @@ class HeaderBar extends React.Component {
         let buttonStyle = { color: '#ffffff' }
 
         // NOTE: mockup for login button functionality
-        let loginButton = <FlatButton style={buttonStyle} linkButton={true} label={<FormattedMessage id="login"/>} onClick={() => this.props.dispatch(login())} />
+        let loginButton = <FlatButton className="mui-flat-button" style={buttonStyle} linkButton={true} label={<FormattedMessage id="login"/>} onClick={() => this.props.dispatch(login())} />
         if(this.props.user) {
-            loginButton = <FlatButton style={buttonStyle} linkButton={true} label={this.props.user.displayName} onClick={() => this.props.dispatch(logout())} />
+            loginButton = <FlatButton className="mui-flat-button" style={buttonStyle} linkButton={true} label={this.props.user.displayName} onClick={() => this.props.dispatch(logout())} />
         }
 
         return (

--- a/src/components/Header/index.scss
+++ b/src/components/Header/index.scss
@@ -38,7 +38,7 @@ $header-bar-height: 56px;
     }
 
     .mui-flat-button {
-        background-color: transparent;
+        background-color: rgba(0,108,188,1) !important;
         color: #ffffff;
 
         margin-left: 6px !important;
@@ -49,7 +49,7 @@ $header-bar-height: 56px;
         }
 
         &:hover {
-            background-color: rgba(255,255,255,0.1);
+            background-color: rgba(255,255,255,0.1) !important;
         }
     }
 


### PR DESCRIPTION
Moving from alpha2 to alpha3, bootstrap 4 deprecated and removed "label" functionality so importing those files led to an error in the build process. In this PR, I've replaced the labels with the new bootstrap class combination ["d-inline bg-danger"](http://v4-alpha.getbootstrap.com/components/utilities/#css-display-block-inline-inline-block), which I take to be the replacement... This will probably break again once a new bootstrap 4 version is released.