### PR TITLE
fix broken build by pinning bs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "babel-polyfill": "^6.3.14",
     "babel-preset-stage-2": "^6.1.18",
     "body-parser": "^1.14.1",
-    "bootstrap": "^4.0.0-alpha.2",
+    "bootstrap": "4.0.0-alpha.2",
     "connect-history-api-fallback": "^1.1.0",
     "cookie-parser": "^1.4.0",
     "cookie-session": "^2.0.0-alpha.1",


### PR DESCRIPTION
Updating bootstrap to the next pre-release breaks build as it removes some files. Fixing this problem led to new problems with the appearance of certain elements in some browsers. These would probably have to be fixed again when the next pre-release comes out, so I suggest following the path of least resistance: pin the working bootstrap pre-release version in the requirements and integrate the new bootstrap 4  it comes out.