### PR TITLE
Source maps enabled in production build

### DIFF
--- a/config/webpack/prod.js
+++ b/config/webpack/prod.js
@@ -53,7 +53,7 @@ var config = {
     },
 
     debug: false,
-
+    devtool: 'source-map',
     resolve: {
         root: common.paths.ROOT,
         extensions: ['.', '', '.webpack.js', '.web.js', '.jsx', '.js']


### PR DESCRIPTION
Fix #159 

Make "production quality" source maps in, well, production.
