### PR TITLE
#161 Display all category lists in two columns

### DIFF
--- a/src/components/EventGrid/index.js
+++ b/src/components/EventGrid/index.js
@@ -27,7 +27,7 @@ let EventItem = (props) => {
 
     return (
         <Link to={url}>
-            <div className="col-xs-12 col-md-6 col-lg-4" key={ props.event['id'] }>
+            <div className="col-xs-4" key={ props.event['id'] }>
                 <div className="event-item">
                     <div className="thumbnail" style={thumbnailStyle} />
                     <div className="name">{name}</div>

--- a/src/components/EventGrid/index.js
+++ b/src/components/EventGrid/index.js
@@ -27,7 +27,7 @@ let EventItem = (props) => {
 
     return (
         <Link to={url}>
-            <div className="col-xs-4" key={ props.event['id'] }>
+            <div className="col-xs-12 col-md-6 col-lg-4" key={ props.event['id'] }>
                 <div className="event-item">
                     <div className="thumbnail" style={thumbnailStyle} />
                     <div className="name">{name}</div>

--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -289,7 +289,7 @@ class FormFields extends React.Component {
                                     ref="hel_main"
                                     name="hel_main"
                                     validationErrors={validationErrors['hel_main']}
-                                    itemClassName="col-sm-12"
+                                    itemClassName="col-md-12 col-lg-6"
                                     options={helMainOptions} />
                     <SideField><p className="tip">Valitse vähintään yksi pääkategoria.</p></SideField>
                 </div>
@@ -300,7 +300,7 @@ class FormFields extends React.Component {
                         ref="audience"
                         name="audience"
                         validationErrors={validationErrors['audience']}
-                        itemClassName="col-sm-12"
+                        itemClassName="col-md-12 col-lg-6"
                         options={helTargetOptions}
                     />
                     <SideField><p className="tip">Jos tapahtumalla ei ole erityistä kohderyhmää, älä valitse mitään.</p></SideField>
@@ -310,7 +310,7 @@ class FormFields extends React.Component {
                         ref="in_language"
                         name="in_language"
                         validationErrors={validationErrors['in_language']}
-                        itemClassName="col-sm-6"
+                        itemClassName="col-md-12 col-lg-6"
                         options={helEventLangOptions}
                     />
                     <SideField><p className="tip">Kielet, joita tapahtumassa käytetään.</p></SideField>

--- a/src/components/HelFormFields/HelLabeledCheckboxGroup.js
+++ b/src/components/HelFormFields/HelLabeledCheckboxGroup.js
@@ -70,14 +70,14 @@ let HelLabeledCheckboxGroup = React.createClass({
         // view half-width checkboxes in two columns
         let left_column = checkboxes
         let right_column = []
-        if(this.props.itemClassName == "col-sm-6") {
+        if(this.props.itemClassName == "col-lg-6") {
             left_column = checkboxes.slice(0, Math.floor(checkboxes.length/2)+1)
             right_column = checkboxes.slice(Math.floor(checkboxes.length/2)+1, checkboxes.length)
         }
         checkboxes = [<div className="left_column" key="1">{left_column}</div>, <div className="right_column" key="2">{right_column}</div>]
 
         return (
-            <fieldset className="checkbox-group col-sm-6">
+            <fieldset className="checkbox-group col-lg-6">
                 <div><span className="legend" style={{position:'relative', width:'auto'}}>{this.props.groupLabel} <ValidationPopover validationErrors={this.props.validationErrors} /></span></div>
                 {checkboxes}
             </fieldset>

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -129,6 +129,7 @@
     "validation-afterStartTime": "Päättymisajan pitää olla alkamisaikaa myöhemmin",
     "validation-inTheFuture": "Tapahtuman pitää olla tulevaisuudessa",
     "validation-shortString": "Tämä kenttä voi olla korkeintaan 160 merkkiä pitkä",
+    "validation-longString": "Tämä kenttä voi olla korkeintaan 5000 merkkiä pitkä",
     "validation-stringLengthCounter": " merkkiä jäljellä",
     "validation-longStringLengthCounter": " merkkiä käytetty",
     "validation-requiredInContentLanguages": "Tämä kenttä vaaditaan kaikilla valituilla kielillä",

--- a/src/validation/validationRules.js
+++ b/src/validation/validationRules.js
@@ -195,9 +195,9 @@ var validations = {
         return true
     },
     longString: function longString(values, value) {
-            if(value.length > 10000) {
-                return false
-            }
+            // if(value.length > 10000) {
+            //     return false
+            // }
     },
     requiredInContentLanguages: function requiredInContentLanguages(values, value) {
         if (typeof value !== 'object') {

--- a/src/validation/validationRules.js
+++ b/src/validation/validationRules.js
@@ -194,10 +194,8 @@ var validations = {
         }
         return true
     },
-    longString: function longString(values, value) {
-            // if(value.length > 10000) {
-            //     return false
-            // }
+    longString: function longString() {
+            return true
     },
     requiredInContentLanguages: function requiredInContentLanguages(values, value) {
         if (typeof value !== 'object') {


### PR DESCRIPTION
Display in two columns in large screens (col-lg-6), and in one column in mid-size screens (col-md-12), to prevent label text from overlapping. 

Also, fix to a form validation bug caused by issue #162.