### PR TITLE
#167 Optimize UI mobile usability

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -212,9 +212,17 @@ header {
 }
 
 @media (max-width: 480px) {
-    h1,h2 {
+    h1 {
+        font-size: 37px;
         padding-top: 40px;
         padding-bottom: 40px;
+    }
+    h2 {
+        padding-top: 40px;
+        padding-bottom: 40px;
+    }
+    #debughelper {
+        bottom: 1em;
     }
 }
 

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -210,3 +210,11 @@ header {
     margin: 0.3em;
     color: #48a3e7;
 }
+
+@media (max-width: 480px) {
+    h1,h2 {
+        padding-top: 40px;
+        padding-bottom: 40px;
+    }
+}
+

--- a/src/components/EventGrid/index.js
+++ b/src/components/EventGrid/index.js
@@ -27,7 +27,7 @@ let EventItem = (props) => {
 
     return (
         <Link to={url}>
-            <div className="col-xs-4" key={ props.event['id'] }>
+            <div className="col-xs-12 col-md-6 col-lg-4" key={ props.event['id'] }>
                 <div className="event-item">
                     <div className="thumbnail" style={thumbnailStyle} />
                     <div className="name">{name}</div>

--- a/src/components/FilterableEventTable/index.js
+++ b/src/components/FilterableEventTable/index.js
@@ -61,7 +61,7 @@ let EventTable = (props) => {
     })
 
     return (
-        <Table selectable={false} multiSelectable={false}>
+        <Table selectable={false} multiSelectable={false} className="event-table">
             <TableHeader enableSelectAll={false} adjustForCheckbox={false} displaySelectAll={false}>
                 <TableRow>
                     <TableHeaderColumn>Otsikko</TableHeaderColumn>

--- a/src/components/FilterableEventTable/index.scss
+++ b/src/components/FilterableEventTable/index.scss
@@ -1,3 +1,18 @@
 .draft-row {
     background-color: rgba(255, 208, 91, 0.60) !important;
 }
+
+.event-table {
+    td, th {
+        overflow-wrap: break-word;
+        white-space: normal !important;
+    }
+}
+
+@media (max-width: 480px) {
+    .event-table {
+        td, th {
+            display: block;
+        }
+    }
+}

--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -157,12 +157,12 @@ class FormFields extends React.Component {
         return (
             <div>
                 <div className="col-sm-12 highlighted-block">
-                    <div className="col-xl-4">
+                    <div className="col-xl-4 col-sm-12">
                         <label>
                             <FormattedMessage id="event-presented-in-languages"/>
                         </label>
                     </div>
-                    <div className="col-xl-8">
+                    <div className="col-xl-8 col-sm-12">
                         <div className="spread-evenly">
                             <HelLanguageSelect options={API.eventInfoLanguages()} checked={contentLanguages} />
                         </div>

--- a/src/components/Header/index.scss
+++ b/src/components/Header/index.scss
@@ -45,7 +45,7 @@ $header-bar-height: 56px;
         margin-right: 6px !important;
 
         &:nth-of-type(1) {
-            margin-left: 18px !important;
+            margin-left: 18px;
         }
 
         &:hover {
@@ -75,3 +75,12 @@ $header-bar-height: 56px;
         padding: 0 !important;
     }
 }
+
+@media (max-width: 480px) {
+    .mui-flat-button {
+        &:nth-of-type(1) {
+            margin-left: 4px !important;
+        }
+    }
+}
+

--- a/src/components/HelFormFields/HelDatePicker.js
+++ b/src/components/HelFormFields/HelDatePicker.js
@@ -53,6 +53,7 @@ let HelDatePicker = React.createClass({
             <DatePicker
                 placeholderText='pp.kk.vvvv'
                 selected={this.state.date}
+                autoOk={true}
                 name={this.props.name}
                 onChange={this.handleChange}
                 onBlur={this.handleBlur}

--- a/src/components/HelFormFields/HelLanguageSelect.js
+++ b/src/components/HelFormFields/HelLanguageSelect.js
@@ -44,7 +44,7 @@ class HelLanguageSelect extends React.Component {
         })
 
         return (
-            <div className="language-selection spread-evenly">
+            <div className="col-xs-12 language-selection">
                 {checkboxes}
             </div>
         )

--- a/src/components/HelFormFields/HelLanguageSelect.js
+++ b/src/components/HelFormFields/HelLanguageSelect.js
@@ -44,7 +44,7 @@ class HelLanguageSelect extends React.Component {
         })
 
         return (
-            <div className="col-xs-12 language-selection">
+            <div className="col-sm-12 language-selection">
                 {checkboxes}
             </div>
         )

--- a/src/components/HelFormFields/NewEvent.scss
+++ b/src/components/HelFormFields/NewEvent.scss
@@ -3,3 +3,7 @@
     left: -5px;
     top: -10px;
 }
+
+.event-languages-label {
+    line-height: 1;
+}

--- a/src/components/ImagePicker/index.scss
+++ b/src/components/ImagePicker/index.scss
@@ -101,3 +101,10 @@ $modal-backdrop-opacity: 0.7;
         background: transparent;
     }
 }
+
+#externalImageURL {
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 7px;
+    margin-bottom: 5px;
+}

--- a/src/components/SearchBar/index.js
+++ b/src/components/SearchBar/index.js
@@ -86,7 +86,7 @@ class SearchBar extends React.Component {
         //var label = this.formatLabel() + ' ';
         return (
             <form onSubmit={ (e) => this.handleSubmit(e) } className="row search-bar">
-                <div className="col-xs-9">
+                <div className="col-sm-8 col-xs-12">
                     <Input
                         type="text"
                         placeholder="Tapahtuman nimi tai paikka"
@@ -97,7 +97,7 @@ class SearchBar extends React.Component {
                         />
                 </div>
 
-                <div className="col-xs-3">
+                <div className="col-sm-4 col-xs-12">
                     <Button style={{height: '72px'}}
                         className="mui-raised-button"
                         type="submit"

--- a/src/components/SearchBar/index.scss
+++ b/src/components/SearchBar/index.scss
@@ -22,6 +22,8 @@ $search-bar-height: 72px;
         font-weight: 300;
         background: #ffffff;
 
+        margin-bottom: 10px;
+
         height: $search-bar-height;
 
         input {

--- a/src/components/ValidationPopover/index.scss
+++ b/src/components/ValidationPopover/index.scss
@@ -62,6 +62,10 @@
 
 @media (max-width: 520px) {
     .validation-error-popover {
+        &.popover {
+            top:-70%;
+            left:0;
+        }
         .popover-content {
             min-width: 100px;
             white-space: normal;
@@ -75,3 +79,4 @@
         }
     }
 }
+

--- a/src/views/Editor/index.scss
+++ b/src/views/Editor/index.scss
@@ -30,7 +30,8 @@
         display: block;
         background-color: #f6f6f6;
 
-        line-height: 72px;
+        //line-height: 72px;
+        line-height: 1.5;
 
         color: #5a5959;
 
@@ -52,8 +53,9 @@
         }
 
         .language-selection {
-            height: 72px;
+            height: 100%;
             width: 100%;
+            padding: 20px;
 
             label {
                 font-size: 20px;

--- a/src/views/Editor/index.scss
+++ b/src/views/Editor/index.scss
@@ -29,6 +29,7 @@
     .highlighted-block {
         display: block;
         background-color: #f6f6f6;
+        padding: 20px;
 
         //line-height: 72px;
         line-height: 1.5;
@@ -55,11 +56,10 @@
         .language-selection {
             height: 100%;
             width: 100%;
-            padding: 20px;
 
             label {
                 font-size: 20px;
-                padding-right: 10px;
+                padding-right: 30px;
             }
         }
     }
@@ -123,4 +123,11 @@
         background-color: #f7f7f7;
         height: 176px;
     }
+}
+
+@media (max-width: 480px) {
+    legend,
+        .legend  {
+            margin-top: 2rem !important;
+        }
 }

--- a/src/views/Editor/index.scss
+++ b/src/views/Editor/index.scss
@@ -12,8 +12,8 @@
 
         .controls {
             position: absolute;
-            right: 10px;
-            bottom: 54px;
+            right: 16px;
+            bottom: 4px;
             display: inline-block;
         }
     }

--- a/src/views/Editor/index.scss
+++ b/src/views/Editor/index.scss
@@ -37,6 +37,7 @@
         label {
             font-size: 24px;
             margin-bottom: 0;
+            line-height: 1.5;
         }
 
         .spread-evenly,


### PR DESCRIPTION
- Fixed margins, paddings, button text visibility, etc. so that elements don’t overlap in mobile. 

- Fixed the tapahtumien hallinta -view on mobile, so that text doesn’t overlap. When designing the look of tables on mobile, there are basically only four options; to 1) squish columns together, 2) enable horizontal scrolling, 3) collapse rows under each other, or 4) collapse columns under each other. In this case it was decided to use option number 3, to collapse rows, so that information is easily visible on mobile. 

- Fixed date picker, so that it closes after user has made a new selection, instead of staying open.

- Moved the floating report error-icon a bit lower, but kept in on the left hand side, since once the error notice slider text is more intuitive if it slides out from the left hand side. Also, most mobile users are right handed, so placing the button on the left hand side prevents users from accidentally pressing the button when scrolling the site. 

- Fixed the ‘etsi tapahtuma’ page on mobile. 