### PR TITLE
Bugfix/ie11 search

### DIFF
--- a/src/actions/events.js
+++ b/src/actions/events.js
@@ -5,7 +5,7 @@ import authedFetch from 'src/utils/authedFetch'
 import { setFlashMsg } from './app'
 
 function makeRequest(query, startDate, endDate) {
-    var url = `${appSettings.api_base}/search/?type=event&q=${query}&page_size=100`
+    var url = `${appSettings.api_base}/search/?type=event&q=${encodeURI(query)}&page_size=100`;
 
     if(appSettings.nocache) {
         url += `&nocache=${Date.now()}`

--- a/src/components/HelFormFields/HelAutoComplete.js
+++ b/src/components/HelFormFields/HelAutoComplete.js
@@ -26,7 +26,7 @@ class HelAutoComplete extends React.Component {
     getOptions(input) {
         let self = this
         this.setState({isLoading: true});
-        return fetch(this.props.dataSource + input)
+        return fetch(this.props.dataSource + encodeURI(input))
             .then((response) => {
                 return response.json();
             }).then((json) => {

--- a/src/components/HelFormFields/HelSelect.js
+++ b/src/components/HelFormFields/HelSelect.js
@@ -26,7 +26,7 @@ class HelSelect extends React.Component {
     }
 
     getOptions(input) {
-        return fetch(this.props.dataSource + input)
+        return fetch(this.props.dataSource + encodeURI(input))
             .then((response) => {
                 return response.json();
             }).then((json) => {


### PR DESCRIPTION
Can't seem to find issue, but these should fix encoding problems with UTF-8 input on IE11 search and autocomplete fields.

I applied encodeURI only to GET requests. Hopefully POST reqs are safe from IE encoding wierdness.
