### PR TITLE
Changed url validation regex to allow urls without protocol identifie…

### DIFF
--- a/src/components/HelFormFields/HelTextField.js
+++ b/src/components/HelFormFields/HelTextField.js
@@ -61,6 +61,7 @@ let HelTextField = React.createClass({
         let longmsg = this.context.intl.formatMessage({id: 'validation-longStringLengthCounter' })
         let isShortString = _.findIndex(this.props.validations, i => i === "shortString") !== -1;
         let isLongString = _.findIndex(this.props.validations, i => i === "longString") !== -1;
+        let isUrl = _.findIndex(this.props.validations, i => i === "isUrl") !== -1;
         if (isShortString === true) {
             return !this.state.error && isShortString
                 ? '' + (160 - this.state.value.length.toString()) + msg
@@ -69,8 +70,13 @@ let HelTextField = React.createClass({
             return !this.state.error && isLongString
                 ? '' + (this.state.value.length.toString()) + longmsg
                 : this.state.error
+        } else if (isUrl === true) {
+            let urlmsg = this.context.intl.formatMessage({id: 'validation-isUrl' })
+            return this.state.error
+                ? urlmsg
+                : this.state.error
         }
-    },
+},
     handleBlur: function (event) {
         // Apply changes to store if no validation errors, or the props 'forceApplyToStore' is defined
         if( this.props.name && this.getValidationErrors().length === 0 &&

--- a/src/components/HelFormFields/NewOffer.js
+++ b/src/components/HelFormFields/NewOffer.js
@@ -80,9 +80,9 @@ class NewOffer extends React.Component {
         return (
             <div key={offerKey} className="offer-fields" style={{'position': 'relative'}}>
                 <label style={{position: 'relative'}}><ValidationPopover validationErrors={this.props.validationErrors} /></label>
-                <MultiLanguageField name="info_url" defaultValue={defaultValue.info_url} ref="info_url" label="event-purchase-link" languages={languages} onBlur={e => this.onBlur(e)} validations={['isUrl']} validationErrors={this.props.validationErrors['info_url']} index={this.props.offerKey}/>
-                <MultiLanguageField name="price" defaultValue={defaultValue.price} disabled={isFree} ref="price" label="event-price" languages={languages} onBlur={e => this.onBlur(e)} validationErrors={this.props.validationErrors['price']} index={this.props.offerKey} />
-                <MultiLanguageField name="description" defaultValue={defaultValue.description} disabled={isFree} ref="description" label="event-price-info" languages={languages} multiLine={true} onBlur={e => this.onBlur(e)} validationErrors={this.props.validationErrors['offer_description']} index={this.props.offerKey} />
+                <MultiLanguageField defaultValue={defaultValue.info_url} ref="info_url" label="event-purchase-link" languages={languages} onBlur={e => this.onBlur(e)} validations={['isUrl']} validationErrors={this.props.validationErrors['info_url']} index={this.props.offerKey}/>
+                <MultiLanguageField defaultValue={defaultValue.price} disabled={isFree} ref="price" label="event-price" languages={languages} onBlur={e => this.onBlur(e)} validationErrors={this.props.validationErrors['price']} index={this.props.offerKey} />
+                <MultiLanguageField defaultValue={defaultValue.description} disabled={isFree} ref="description" label="event-price-info" languages={languages} multiLine={true} onBlur={e => this.onBlur(e)} validationErrors={this.props.validationErrors['offer_description']} index={this.props.offerKey} />
                 <Button
                     raised
                     onClick={() => this.deleteOffer()}

--- a/src/components/HelFormFields/NewOffer.js
+++ b/src/components/HelFormFields/NewOffer.js
@@ -7,6 +7,7 @@ import ValidationPopover from 'src/components/ValidationPopover'
 import { setOfferData, deleteOffer } from 'src/actions/editor.js'
 // Material-ui Icons
 import Delete from 'material-ui-icons/Delete'
+import { FormattedMessage } from 'react-intl'
 
 class NewOffer extends React.Component {
     static contextTypes = {
@@ -21,11 +22,11 @@ class NewOffer extends React.Component {
 
     onBlur(e) {
         if(this.props.offerKey) {
-            if(this.noValidationErrors()) {
+//            if(this.noValidationErrors()) {
                 let obj = {}
                 obj[this.props.offerKey] = this.buildObject()
                 this.context.dispatch(setOfferData(obj, this.props.offerKey))
-            }
+//            }
         }
     }
 
@@ -78,9 +79,10 @@ class NewOffer extends React.Component {
         }
         return (
             <div key={offerKey} className="offer-fields" style={{'position': 'relative'}}>
-                <MultiLanguageField defaultValue={defaultValue.info_url} ref="info_url" label="event-purchase-link" languages={languages} onBlur={e => this.onBlur(e)} validations={['isUrl']}  />
-                <MultiLanguageField defaultValue={defaultValue.price} disabled={isFree} ref="price" label="event-price" languages={languages} onBlur={e => this.onBlur(e)} validationErrors={this.props.validationErrors['price']} index={this.props.offerKey} />
-                <MultiLanguageField defaultValue={defaultValue.description} disabled={isFree} ref="description" label="event-price-info" languages={languages} multiLine={true} onBlur={e => this.onBlur(e)} validationErrors={this.props.validationErrors['offer_description']} index={this.props.offerKey} />
+                <label style={{position: 'relative'}}><ValidationPopover validationErrors={this.props.validationErrors} /></label>
+                <MultiLanguageField name="info_url" defaultValue={defaultValue.info_url} ref="info_url" label="event-purchase-link" languages={languages} onBlur={e => this.onBlur(e)} validations={['isUrl']} validationErrors={this.props.validationErrors['info_url']} index={this.props.offerKey}/>
+                <MultiLanguageField name="price" defaultValue={defaultValue.price} disabled={isFree} ref="price" label="event-price" languages={languages} onBlur={e => this.onBlur(e)} validationErrors={this.props.validationErrors['price']} index={this.props.offerKey} />
+                <MultiLanguageField name="description" defaultValue={defaultValue.description} disabled={isFree} ref="description" label="event-price-info" languages={languages} multiLine={true} onBlur={e => this.onBlur(e)} validationErrors={this.props.validationErrors['offer_description']} index={this.props.offerKey} />
                 <Button
                     raised
                     onClick={() => this.deleteOffer()}

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -122,7 +122,7 @@
     "ruotsi": "ruotsi",
     "suomi": "suomi",
 
-    "validation-isUrl": "Kirjoita URL osoite kokonaisena ja oikeassa muodossa (http://...)",
+    "validation-isUrl": "Tarkista URL osoitteen kirjoitusmuoto",
     "validation-isTime": "Kirjoita aika oikeassa muodossa HH.mm tai HH",
     "validation-isDate": "Kirjoita päivämäärä muodossa pp.kk.vvvv tai p.k.vvvv",
     "validation-atLeastOne": "Valitse vähintään yksi kategoria",

--- a/src/reducers/editor.js
+++ b/src/reducers/editor.js
@@ -39,8 +39,10 @@ function clearEventDataFromLocalStorage() {
 
 function update(state = initialState, action) {
     if (action.type === constants.EDITOR_SETDATA) {
+        let newValues = {}
+        // Merge new values to existing values
         if (action.event) {
-            return updater(state, {
+            newValues = updater(state, {
                 values: {
                     sub_events: {
                         [action.key]: {
@@ -49,9 +51,9 @@ function update(state = initialState, action) {
                     }
                 }
             });
-        }
-        if (action.offer) {
-            return updater(state, {
+            newValues = newValues.values
+        } if (action.offer) {
+            newValues = updater(state, {
                 values: {
                     offers: {
                         [action.key]: {
@@ -60,17 +62,42 @@ function update(state = initialState, action) {
                     }
                 }
             });
+            newValues = newValues.values
+        } else {
+            newValues = Object.assign({}, state.values, action.values)
         }
-        // Merge new values to existing values
-        let newValues = Object.assign({}, state.values, action.values)
-
+    
         // Local storage saving disabled for now
         // localStorage.setItem('EDITOR_VALUES', JSON.stringify(newValues))
-
+    
         let validationErrors = Object.assign({}, state.validationErrors)
         // If there are validation errors, check if they are fixed
         if (_.keys(state.validationErrors).length > 0) {
             validationErrors = doValidations(newValues, state.contentLanguages, state.validateFor || constants.PUBLICATION_STATUS.PUBLIC)
+        }
+
+        if (action.event) {
+            return updater(state, {
+                values: {
+                    sub_events: {
+                        [action.key]: {
+                            $set: newValues.sub_events[action.key]
+                        }
+                    }
+                },
+                validationErrors: {$set: validationErrors}
+            });
+        } else if (action.offer) {
+            return updater(state, {
+                values: {
+                    offers: {
+                        [action.key]: {
+                            $set: newValues.offers[action.key]
+                        }
+                    }
+                },
+                validationErrors: {$set: validationErrors}
+            });
         }
 
         return Object.assign({}, state, {

--- a/src/validation/validationRules.js
+++ b/src/validation/validationRules.js
@@ -64,7 +64,7 @@ const _isUrl = function(values, value) {
         "$", "i"
       )
 
-    return validations.matchRegexp(values, value, urlRegexp)
+      return validations.matchRegexp(values, value, urlRegexp)
 }
 
 var validations = {
@@ -86,11 +86,28 @@ var validations = {
     isEmail: function isEmail(values, value) {
         return validations.matchRegexp(values, value, /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i);
     },
-    isUrl: function isUrl(values, value) {
+    isUrl: function isUrl(values, value, key) {
         if (typeof value === 'object') {
-            return _.every(value, (item) => {
-                return _isUrl(values, item)
-            })
+            if (typeof key !== 'undefined') {
+                // Check all language urls
+                let finnishUrlValidationPassed = true
+                let englishUrlValidationPassed = true
+                let swedishUrlValidationPassed = true
+                if (value[key].fi) {
+                    finnishUrlValidationPassed = _isUrl(values, value[key].fi)
+                }
+                if (value[key].en) {
+                    englishUrlValidationPassed = _isUrl(values, value[key].en)
+                }
+                if (value[key].sv) {
+                    swedishUrlValidationPassed = _isUrl(values, value[key].sv)
+                }
+                return finnishUrlValidationPassed && englishUrlValidationPassed && swedishUrlValidationPassed
+            } else {
+                return _.every(value, (item) => {
+                    return _isUrl(values, item)
+                })
+            }
         }
         return _isUrl(values, value)
     },

--- a/src/validation/validationRules.js
+++ b/src/validation/validationRules.js
@@ -27,7 +27,44 @@ const _containsAllLanguages = function _containsAllLanguages(value, languages) {
 }
 
 const _isUrl = function(values, value) {
-    return validations.matchRegexp(values, value, /^(https?|s?ftp):\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i);
+    const urlRegexp = new RegExp(
+        "^" +
+          // protocol identifier
+          "(?:(?:https?:|ftps?:)?//)?" +
+          // user:pass authentication
+          "(?:\\S+(?::\\S*)?@)?" +
+          "(?:" +
+            // IP address exclusion
+            // private & local networks
+            "(?!(?:10|127)(?:\\.\\d{1,3}){3})" +
+            "(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})" +
+            "(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})" +
+            // IP address dotted notation octets
+            // excludes loopback network 0.0.0.0
+            // excludes reserved space >= 224.0.0.0
+            // excludes network & broacast addresses
+            // (first & last IP address of each class)
+            "(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])" +
+            "(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}" +
+            "(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))" +
+          "|" +
+            // host name
+            "(?:(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)" +
+            // domain name
+            "(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*" +
+            // TLD identifier
+            "(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))" +
+            // TLD may end with dot
+            "\\.?" +
+          ")" +
+          // port number
+          "(?::\\d{2,5})?" +
+          // resource path
+          "(?:[/?#]\\S*)?" +
+        "$", "i"
+      )
+
+    return validations.matchRegexp(values, value, urlRegexp)
 }
 
 var validations = {

--- a/src/validation/validator.js
+++ b/src/validation/validator.js
@@ -63,7 +63,7 @@ function runValidationWithSettings(values, languages, settings) {
     _.each(settings, (validations, key) => {
         // Returns an array of validation errors (array of nulls if validation passed)
         let errors = validations.map(validation => {
-            if (key === 'offer_description' || key === 'price') {
+            if (key === 'offer_description' || key === 'price' || key === 'info_url') {
                 return validateCollection(valuesWithLanguages, key, validation, 'offers')
             }
             return validationFn[validation](valuesWithLanguages, values[key]) ? null : validation


### PR DESCRIPTION
fixes #239. Changed regexp to allow addresses without protocol identifier (ie. http(s) or ftp(s)). Regex also includes optional user authentication and excludes local IP addresses. I could not reproduce the showing of error message in wrong fields, maybe its already corrected in some previous commit?