### PR TITLE
255 ending time swallows errors

### DIFF
--- a/src/components/HelFormFields/HelTextField.js
+++ b/src/components/HelFormFields/HelTextField.js
@@ -47,7 +47,11 @@ let HelTextField = React.createClass({
         })
 
         this.recalculateHeight()
-        this.setValidationErrorsToState()
+
+        let isTime = _.findIndex(this.props.validations, i => i === "isTime") !== -1;
+        if (isTime === false){
+            this.setValidationErrorsToState()
+        }
 
         if(typeof this.props.onChange === 'function') {
             this.props.onChange(event, this.refs.text.getValue())
@@ -55,21 +59,32 @@ let HelTextField = React.createClass({
     },
 
     helpText: function() {
-        let msg = this.context.intl.formatMessage({id: 'validation-stringLengthCounter' })
-        let longmsg = this.context.intl.formatMessage({id: 'validation-longStringLengthCounter' })
         let isShortString = _.findIndex(this.props.validations, i => i === "shortString") !== -1;
         let isLongString = _.findIndex(this.props.validations, i => i === "longString") !== -1;
+        let isTime = _.findIndex(this.props.validations, i => i === "isTime") !== -1;
         if (isShortString === true) {
+            let msg = this.context.intl.formatMessage({id: 'validation-stringLengthCounter' })
             return !this.state.error && isShortString
                 ? '' + (160 - this.state.value.length.toString()) + msg
                 : this.state.error
         } else if (isLongString === true) {
+            let longmsg = this.context.intl.formatMessage({id: 'validation-longStringLengthCounter' })
             return !this.state.error && isLongString
                 ? '' + (this.state.value.length.toString()) + longmsg
                 : this.state.error
+        } else if (isTime === true) {
+            let timemsg = this.context.intl.formatMessage({id: 'validation-isTime' })
+            return this.state.error
+                ? timemsg
+                : ''
         }
     },
     handleBlur: function (event) {
+        let isTime = _.findIndex(this.props.validations, i => i === "isTime") !== -1;
+        if (isTime === true) {  //Time field error is shown only after blur
+            this.setValidationErrorsToState()
+        }
+
         // Apply changes to store if no validation errors, or the props 'forceApplyToStore' is defined
         if( this.props.name && this.getValidationErrors().length === 0 &&
             !this.props.name.includes('time') ||

--- a/src/components/HelFormFields/HelTimePicker.js
+++ b/src/components/HelFormFields/HelTimePicker.js
@@ -29,6 +29,7 @@ let HelTimePicker = React.createClass({
                 onChange={this.handleChange}
                 onBlur={this.handleBlur}
                 defaultValue={this.props.defaultValue}
+                forceApplyToStore
             />
         )
     }

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -125,6 +125,7 @@
     "validation-isUrl": "Kirjoita URL osoite kokonaisena ja oikeassa muodossa (http://...)",
     "validation-isTime": "Kirjoita aika oikeassa muodossa HH.mm tai HH",
     "validation-isDate": "Kirjoita päivämäärä muodossa pp.kk.vvvv tai p.k.vvvv",
+    "validation-isIsoDate": "Syötä kellonaika muodossa tt.mm",
     "validation-atLeastOne": "Valitse vähintään yksi kategoria",
     "validation-requiredMulti": "Tämä kenttä vaaditaan",
     "validation-requiredAtId": "Tämä kenttä vaaditaan",

--- a/src/validation/validationRules.js
+++ b/src/validation/validationRules.js
@@ -108,6 +108,10 @@ var validations = {
     isDate: function isDate(values, value) {
         return validations.matchRegexp(values, value, /^[0-9]{4}\-[0-9]{2}\-[0-9]{2}$/i);
     },
+    isIsoDate: function isIsoDate(values, value) {
+        if(!value) { return true }
+        return moment(value, moment.ISO_8601).isValid()
+    },
     afterStartTime: function afterStartTime(values, value) {
         if(!values.start_time || !value) { return true }
 

--- a/src/validation/validationRules.js
+++ b/src/validation/validationRules.js
@@ -103,7 +103,7 @@ var validations = {
         return !_isExisty(value) || isEmpty(value) || value.length >= length;
     },
     isTime: function isTime(values, value) {
-        return validations.matchRegexp(values, value, /(24:00)|(^(2[0-3]|1[0-9]|0[0-9]|[0-9])((:|\.)[0-5][0-9]))?$/i);
+        return validations.matchRegexp(values, value, /^(24:00|(2[0-3]|1[0-9]|0[0-9]|[0-9])((:|\.)[0-5][0-9]))$/i);
     },
     isDate: function isDate(values, value) {
         return validations.matchRegexp(values, value, /^[0-9]{4}\-[0-9]{2}\-[0-9]{2}$/i);

--- a/src/validation/validator.js
+++ b/src/validation/validator.js
@@ -20,8 +20,8 @@ const publicValidations = {
     name: ['requiredMulti', 'requiredInContentLanguages'],
     location: ['requiredAtId'],
     hel_main: ['atLeastOne'],
-    start_time: ['requiredString'], // Datetime is saved as ISO string
-    end_time: ['afterStartTime', 'inTheFuture'],
+    start_time: ['requiredString', 'isIsoDate'], // Datetime is saved as ISO string
+    end_time: ['isIsoDate', 'afterStartTime', 'inTheFuture'],
     offer_description: ['hasPrice'],
     price: ['hasPrice'],
     short_description: ['requiredMulti', 'requiredInContentLanguages', 'shortString'],


### PR DESCRIPTION
Fixes #255 . Fixed date and time validations so that validations will be done correctly against entered data and possible error messages will be shown besides the fields.

Validations had a couple of issues for end/start dates:
-Data was validated but error in time field was not shown. When user pressed "save" the data was sent from Redux store which was coded to receive only valid data -> That caused the previous valid time to be POSTed and no errors shown.
-Date and Time field were bound to the same redux statetree node -> That caused all kinds of interesting problems in validations depending on which order you filled the fields.