### PR TITLE
config: turn on nconf environment parsing to support booleans

### DIFF
--- a/config/webpack/dev.js
+++ b/config/webpack/dev.js
@@ -11,7 +11,7 @@ const templateConfigKeys = ['LE_PRODUCTION_INSTANCE', 'APP_MODE'];
 
 const gitRevisionPlugin = new GitRevisionPlugin();
 
-nconf.env(jsonConfigKeys.concat(templateConfigKeys));
+nconf.env({ parseValues: true, whitelist: jsonConfigKeys.concat(templateConfigKeys)});
 nconf.defaults({
     'LE_PRODUCTION_INSTANCE': '#',
     'APP_MODE': 'production',


### PR DESCRIPTION
This broke disabling raven through environment. Ie. raven_id was set to "false" instead of false