### PR TITLE
268 lisaa uusi ajankohta does not work

### DIFF
--- a/src/utils/formDataMapping.js
+++ b/src/utils/formDataMapping.js
@@ -166,6 +166,13 @@ function mapAPIDataToUIFormat(values) {
         obj.offers = values.offers
     }
 
+    // Subevents
+    if (values.sub_events.length === 0) {
+        obj.sub_events = {}
+    } else {
+        obj.sub_events = values.sub_events
+    }
+
     // TODO: Filter hel_main categories from keywords, non-hel_main categories from hel_main
     //
     let keywords = _.cloneDeep(values.keywords)

--- a/src/views/App/index.js
+++ b/src/views/App/index.js
@@ -118,13 +118,19 @@ class App extends React.Component {
         const getMarkup = () => ({__html: additionalMarkup})
 
         let buttonStyle = {
-            marginLeft: '10px'
+            marginLeft: '10px',
+            color: 'white',
+            backgroundColor: '#1976d2'
         }
 
         let warningButtonStyle = {
-            'marginLeft': '10px',
-            background: 'red',
+            marginLeft: '10px',
+            color: 'white',
             backgroundColor: 'red'
+        }
+        let useWarningButtonStyle = false
+        if (this.props.app.confirmAction && this.props.app.confirmAction.style === 'warning') {
+            useWarningButtonStyle = true
         }
 
         let isWarningModal = false;
@@ -165,8 +171,8 @@ class App extends React.Component {
                         <div dangerouslySetInnerHTML={getMarkup()}/>
                     </Modal.Body>
                     <Modal.Footer>
-                        <MaterialButton style={buttonStyle} label={<FormattedMessage id="cancel" />} onClick={e => this.props.dispatch(cancelAction())} />
-                        <MaterialButton style={buttonStyle} backgroundColor={isWarningModal ? 'rgba(255,160,160,1)' : null} label={<FormattedMessage id={actionButtonLabel} />} onClick={e => this.props.dispatch(doAction(this.props.app.confirmAction.data))} />
+                        <MaterialButton style={buttonStyle} onClick={e => this.props.dispatch(cancelAction())}><FormattedMessage id="cancel" /></MaterialButton>
+                        <MaterialButton style={useWarningButtonStyle ? warningButtonStyle : buttonStyle} onClick={e => this.props.dispatch(doAction(this.props.app.confirmAction.data))}><FormattedMessage id={actionButtonLabel} /></MaterialButton>
                     </Modal.Footer>
                     </Modal>
                 </div>


### PR DESCRIPTION
This should fix the adding of subevents and also the confirmation dialog button text & color which were still using the Material-UI pre v1 syntax.