### PR TITLE
Whole day event functionality.

### DIFF
--- a/src/actions/editor.js
+++ b/src/actions/editor.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { includes } from 'lodash';
 
 import constants from '../constants'
-import {mapUIDataToAPIFormat} from 'src/utils/formDataMapping.js'
+import {mapUIDataToAPIFormat, removeTimePartFromIsoDate} from 'src/utils/formDataMapping.js'
 
 import { pushPath } from 'redux-simple-router'
 import { setFlashMsg, confirmAction } from './app'
@@ -135,6 +135,17 @@ export function validateFor(publicationStatus) {
     }
 }
 
+function removeTimePartIfWholeDayEvent(event) {
+    // mapUIDataToAPIFormat
+    if (event.isWholeDayEvent) {
+        event.start_time = removeTimePartFromIsoDate(event.start_time)
+        event.end_time = removeTimePartFromIsoDate(event.end_time)
+        return event
+    } else {
+        return event
+    }
+}
+
 /**
  * Send form values data. A UI to API data mapping is done before sending the values
  * @param  {[type]} formValues              [description]
@@ -187,13 +198,19 @@ export function sendData(formValues, contentLanguages, user, updateExisting = fa
             let endDates = [];
             for(const key in subEvents) {
                 if(subEvents.hasOwnProperty(key)) {
-                    endDates.push(moment(subEvents[key].end_time))
+                    if (!subEvents[key].isWholeDayEvent) {
+                        endDates.push(moment(subEvents[key].end_time))
+                    } else {
+                        //Whole day event, time part is removed
+                        endDates.push(moment(removeTimePartFromIsoDate(subEvents[key].end_time)))
+                    }
+
                 }
             }
             let newSubEvents = Object.assign({}, {[0]: {start_time: data.start_time, end_time: data.end_time}});
             for(const key in subEvents) {
                 if(subEvents.hasOwnProperty(key)) {
-                    newSubEvents = Object.assign({}, newSubEvents, {[key+1]: subEvents[key]});
+                    newSubEvents = Object.assign({}, newSubEvents, {[key+1]: removeTimePartIfWholeDayEvent(subEvents[key])});
                 }
             }
             data.end_time = moment.tz(moment.max(endDates), 'Europe/Helsinki').utc().toISOString();
@@ -239,6 +256,7 @@ export function sendData(formValues, contentLanguages, user, updateExisting = fa
         if(user) {
              token = user.token
         }
+
         // Set publication status for editor values. This is used by the validation to determine
         // which set of rules to use
         dispatch(validateFor(publicationStatus))

--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -109,6 +109,11 @@ class FormFields extends React.Component {
         let endTime
         let subEventKeys = Object.keys(this.props.editor.values.sub_events)
         let key = subEventKeys.length > 0 ? Math.max.apply(null, subEventKeys)+1 : 1
+        let previousEventWasWholeDay = false
+        if (subEventKeys.length === 0 && this.props.editor.values.hasOwnProperty('isWholeDayEvent')) {
+            previousEventWasWholeDay = this.props.editor.values.isWholeDayEvent
+        }
+
         if (_.keys(this.props.editor.values.sub_events).length) {
             const subEvents = this.props.editor.values.sub_events
             const startDates = []
@@ -117,6 +122,7 @@ class FormFields extends React.Component {
                 if (subEvents.hasOwnProperty(key)) {
                     startDates.push(moment(subEvents[key].start_time))
                     endDates.push(moment(subEvents[key].end_time))
+                    previousEventWasWholeDay = subEvents[key].isWholeDayEvent
                 }
             }
             startTime = moment.max(startDates)
@@ -127,7 +133,8 @@ class FormFields extends React.Component {
         }
         obj[key] = {
             start_time: moment.tz(startTime.add(1, 'weeks'), 'Europe/Helsinki').utc().toISOString(),
-            end_time: moment.tz(endTime.add(1, 'weeks'), 'Europe/Helsinki').utc().toISOString()
+            end_time: moment.tz(endTime.add(1, 'weeks'), 'Europe/Helsinki').utc().toISOString(),
+            isWholeDayEvent: previousEventWasWholeDay
         }
         this.context.dispatch(setEventData(obj, key))
     }
@@ -228,10 +235,10 @@ class FormFields extends React.Component {
                     <div className="col-sm-6">
                         <div className="row">
                             <div className="col-xs-12 col-md-6">
-                                <HelDateTimeField validationErrors={validationErrors['start_time']} defaultValue={values['start_time']} ref="start_time" name="start_time" label="event-starting-datetime" setDirtyState={this.props.setDirtyState} />
+                                <HelDateTimeField validationErrors={validationErrors['start_time']} defaultValue={values['start_time']} ref="start_time" name="start_time" label="event-starting-datetime" setDirtyState={this.props.setDirtyState} showWholeDayEventSwitch isWholeDayEvent={values['isWholeDayEvent']}/>
                             </div>
                             <div className="col-xs-12 col-md-6">
-                                <HelDateTimeField validationErrors={validationErrors['end_time']} defaultValue={values['end_time']} ref="end_time" name="end_time" label="event-ending-datetime" setDirtyState={this.props.setDirtyState} />
+                                <HelDateTimeField validationErrors={validationErrors['end_time']} defaultValue={values['end_time']} ref="end_time" name="end_time" label="event-ending-datetime" setDirtyState={this.props.setDirtyState} isWholeDayEvent={values['isWholeDayEvent']}/>
                             </div>
                         </div>
                         <div className={"new-events " + (this.state.showNewEvents ? 'show' : 'hidden')}>

--- a/src/components/HelFormFields/HelCheckbox.scss
+++ b/src/components/HelFormFields/HelCheckbox.scss
@@ -4,7 +4,7 @@
     line-height: 32px;
 
     input {
-        margin-right: 14px;
+        margin-right: 4px;
     }
 
     label {
@@ -14,7 +14,7 @@
         }
 
         span {
-            padding-left: 14px;
+            padding-left: 4px;
         }
     }
 

--- a/src/components/HelFormFields/HelDateTimeField.js
+++ b/src/components/HelFormFields/HelDateTimeField.js
@@ -3,7 +3,7 @@ import React from 'react'
 import HelTextField from './HelTextField.js'
 import HelDatePicker from './HelDatePicker.js'
 import HelTimePicker from './HelTimePicker.js'
-
+import HelCheckbox from './HelCheckbox'
 
 import {connect} from 'react-redux'
 import {setData, updateSubEvent} from 'src/actions/editor.js'
@@ -65,11 +65,12 @@ const HelDateTimeField = React.createClass({
             if(actualErrors.length === 0) {
                 let datetime = this.getDateTimeFromFields(date, time)
                 if(datetime) {
-                    let obj = {}
-                    obj[this.props.name] = datetime
                     if(this.props.eventKey){
                         this.context.dispatch(updateSubEvent(datetime, this.props.name, this.props.eventKey))
                     } else {
+                        let obj = {}
+                        obj[this.props.name] = datetime
+                        obj[this.props.name + 'WholeDayEvent'] = this.state.isWholeDayEvent
                         this.context.dispatch(setData(obj))
                     }
 
@@ -150,13 +151,29 @@ const HelDateTimeField = React.createClass({
         return true
     },
 
+    setIsWholeDayEvent(e, value) {
+        if(this.props.eventKey){
+            //Subevent
+            this.context.dispatch(updateSubEvent(value, 'isWholeDayEvent', this.props.eventKey))
+        } else {
+            let obj = {}
+            obj['isWholeDayEvent'] = value
+            this.context.dispatch(setData(obj))
+        }
+    },
+
     render: function () {
         return (
             <div className="multi-field">
                 <div className="indented">
                     <label style={{position: 'relative'}}><FormattedMessage id={`${this.props.label}`} /> <ValidationPopover validationErrors={this.props.validationErrors} /></label>
                     <HelDatePicker ref="date" name={this.props.name} defaultValue={this.state.date} validations={['isDate']} placeholder="pp.kk.vvvv" onChange={this.onChange} onBlur={this.onBlur} label={<FormattedMessage id="date" />} />
+                    {!this.props.isWholeDayEvent &&
                     <HelTimePicker ref="time" name={this.props.name} defaultValue={this.state.time} validations={['isTime']} placeholder="hh.mm" onChange={this.onChange} onBlur={this.onBlur} label={<FormattedMessage id="time" />} />
+                    }
+                    {!!this.props.showWholeDayEventSwitch === true &&
+                       <HelCheckbox defaultChecked={this.props.isWholeDayEvent} label={<FormattedMessage id="event-whole-day-event"/>} onChange={(e,v) => this.setIsWholeDayEvent(e,v)}/>
+                    }
                 </div>
             </div>
         )

--- a/src/components/HelFormFields/MultiLanguageField.scss
+++ b/src/components/HelFormFields/MultiLanguageField.scss
@@ -7,7 +7,7 @@
     }
 
     .indented {
-        padding: 3px 23px 11.5px 23px;
+        padding: 3px 8px 11.5px 23px;
         border-left: 5px solid #f7f7f7;
 
         > label {

--- a/src/components/HelFormFields/NewEvent.js
+++ b/src/components/HelFormFields/NewEvent.js
@@ -35,6 +35,8 @@ class NewEvent extends React.Component {
                                 label="event-starting-datetime"
                                 defaultValue={this.props.event.start_time}
                                 eventKey={this.props.eventKey}
+                                showWholeDayEventSwitch
+                                isWholeDayEvent={this.props.event.isWholeDayEvent}
                             />
                         </div>
                         <div className="col-xs-12 col-md-6">
@@ -44,6 +46,7 @@ class NewEvent extends React.Component {
                                 label="event-ending-datetime"
                                 defaultValue={this.props.event.end_time}
                                 eventKey={this.props.eventKey}
+                                isWholeDayEvent={this.props.event.isWholeDayEvent}
                             />
                         </div>
                         <Button

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -56,6 +56,7 @@
     "event-datetime-fields-header": "Tapahtuman ajankohdat",
     "event-starting-datetime": "Tapahtuma alkaa",
     "event-ending-datetime": "Tapahtuma päättyy",
+    "event-whole-day-event": "Koko päivän tapahtuma",
     "event-add-new-occasion": "Lisää uusi ajankohta",
     "event-add-recurring": "Toistuva tapahtuma",
     "event-add-price": "Lisää uusi hintatieto",

--- a/src/utils/formDataMapping.js
+++ b/src/utils/formDataMapping.js
@@ -8,7 +8,8 @@ import {mapLanguagesSetToForm} from 'src/utils/apiDataMapping.js'
 
 export {
     mapUIDataToAPIFormat,
-    mapAPIDataToUIFormat
+    mapAPIDataToUIFormat,
+    removeTimePartFromIsoDate
 }
 
 // hel.fi audience keywords that correspond to YSO audience keywords need to be posted also for now
@@ -123,11 +124,19 @@ function mapUIDataToAPIFormat(values) {
     })
 
     if(values.start_time) {
-        obj.start_time = values.start_time
+        if (values.isWholeDayEvent) {
+            obj.start_time = removeTimePartFromIsoDate(values.start_time)
+        } else {
+            obj.start_time = values.start_time
+        }
     }
 
     if(values.end_time) {
-        obj.end_time = values.end_time
+        if (values.isWholeDayEvent) {
+            obj.end_time = removeTimePartFromIsoDate(values.end_time)
+        } else {
+            obj.end_time = values.end_time
+        }
     }
 
     return obj
@@ -135,6 +144,14 @@ function mapUIDataToAPIFormat(values) {
     /*
     'date_published': DATETIME, // Not required at the moment...
     */
+}
+
+function removeTimePartFromIsoDate(date){
+    if (date.indexOf('T') > 0) {
+        return date.substr(0, date.indexOf('T'))
+    } else {
+        return date
+    }
 }
 
 function mapAPIDataToUIFormat(values) {


### PR DESCRIPTION
Resolves #54 .

This adds a whole day checkbox which hides hour inputs for the event. This has not yet been fully tested as API does not yet accept dates without timestamp, so might need some commits more.