### PR TITLE
Check event editability consistently and support user admin_organizations array from API

### DIFF
--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -41,8 +41,12 @@ export function retrieveUserFromSession() {
                 }
                 return fetch(`${appSettings.api_base}/user/${user.username}/`, settings).then((response) => {
                     return response.json()
-                }).then((organizationJSON) => {
-                    let mergedUser = Object.assign({}, user, { organization: _.get(organizationJSON, 'organization', null) })
+                }).then((userJSON) => {
+                    let mergedUser = Object.assign({}, user, {
+                        organization: _.get(userJSON, 'organization', null),
+                        adminOrganizations: _.get(userJSON, 'admin_organizations', null),
+                        organizationMemberships: _.get(userJSON, 'organization_memberships', null)
+                    })
 
                     saveUserToLocalStorage(mergedUser)
                     return dispatch(receiveUserData(mergedUser))

--- a/src/utils/checkEventEditability.js
+++ b/src/utils/checkEventEditability.js
@@ -1,0 +1,72 @@
+import constants from 'src/constants'
+import moment from 'moment'
+
+export function userMayEdit(user, event) {
+    let userMayEdit = false
+    // For simplicity, support both old and new user api.
+    // Check admin_organizations and organization_membership, but fall back to user.organization if needed
+    if (user && user.adminOrganizations) {
+        // TODO: in the future, we will need information (currently not present) on whether event.organization is
+        // a suborganization of the user admin_organization. This should be done in the API by e.g.
+        // including all superorganizations of a suborganization in the suborganization API JSON,
+        // and fetching that json for the event organization.
+        userMayEdit = (event && user && event.organization &&
+        user.adminOrganizations.includes(event.organization))
+    } else {
+        userMayEdit = (event && user && event.organization &&
+        user.organization === event.organization)
+    }
+
+    // exceptions to the above:
+    if (user && user.organizationMemberships && !userMayEdit) {
+        // non-admins may still edit drafts if they are organization members
+        userMayEdit = (event && user && event.organization &&
+        user.organizationMemberships.includes(event.organization) &&
+        event.publication_status == constants.PUBLICATION_STATUS.DRAFT )
+    }
+    if (user && (user.organization || user.adminOrganizations) && !event.organization) {
+        // if event has no organization, we are creating a new event. it is allowed for users with organizations,
+        // disallowed for everybody else. event organization is set by the API when POSTing.
+        userMayEdit = true
+    }
+
+    return userMayEdit
+}
+
+export function eventIsCancelled(event) {
+    let eventIsCancelled = (event && event.event_status == constants.EVENT_STATUS.CANCELLED)
+    return eventIsCancelled
+}
+
+export function eventIsInThePast(event) {
+    //Check if event (end time) is in the past. If event is in the past then editing is not allowed
+    let eventIsInThePast = false
+    if (event && event.end_time) {
+        //Convert to moment object
+        let endTime = moment(event.end_time, moment.defaultFormatUtc)
+        let currentDate = moment()
+        if (currentDate.diff(endTime) > 0) {
+            //Event is in the past
+            eventIsInThePast = true
+        }
+    }
+    return eventIsInThePast
+}
+
+export function checkEventEditability(user, event) {
+    let eventEditabilityExplanation = ''
+    let eventIsInThePast = module.exports.eventIsInThePast(event)
+    if (eventIsInThePast) {
+        eventEditabilityExplanation = 'Menneisyydessä olevia tapahtumia ei voi muokata.'
+    }
+    let eventIsCancelled = module.exports.eventIsCancelled(event)
+    if (eventIsCancelled) {
+        eventEditabilityExplanation = 'Peruttuja tapahtumia ei voi muokata.'
+    }
+    let userMayEdit = module.exports.userMayEdit(user, event)
+    if (!userMayEdit) {
+        eventEditabilityExplanation = 'Sinulla ei ole oikeuksia muokata tätä tapahtumaa.'
+    }
+    return {eventIsEditable: !eventIsInThePast && !eventIsCancelled && userMayEdit, eventEditabilityExplanation}
+}
+

--- a/src/views/Event/index.js
+++ b/src/views/Event/index.js
@@ -18,6 +18,7 @@ import {pushPath} from 'redux-simple-router'
 import {getStringWithLocale} from 'src/utils/locale'
 import {mapAPIDataToUIFormat} from 'src/utils/formDataMapping.js'
 import {replaceData} from 'src/actions/editor.js'
+import {checkEventEditability} from 'src/utils/checkEventEditability.js'
 
 import constants from 'src/constants'
 
@@ -50,6 +51,7 @@ class EventPage extends React.Component {
     }
 
     render() {
+        const user = this.props.user
         let buttonStyle = {
             height: '64px',
             marginRight: '10px',
@@ -61,30 +63,8 @@ class EventPage extends React.Component {
         // To prevent 'Can't access field of undefined errors'
         event.location = event.location || {}
 
-        // User can edit event
-        let userCanEdit = false
-
-        // TODO: refactor to a utils function
-        if(event && this.props.user && event.event_status !== constants.EVENT_STATUS.CANCELLED &&
-        this.props.user.organization && event.organization && this.props.user.organization === event.organization) {
-            userCanEdit = true
-        }
-
-        // User can edit event
-        let eventIsInThePast = false
-
-        let editEventTooltipTitle = ''
-        //Check if event (end time) is in the past. If event is in the past then editing is not allowed
-        if (userCanEdit == true && event.end_time) {
-            //Convert to moment object
-            let endTime = moment(event.end_time, moment.defaultFormatUtc)
-            let currentDate = moment()
-            if (currentDate.diff(endTime) > 0) {
-                //Event is in the past
-                userCanEdit = false
-                editEventTooltipTitle = 'Menneisyydessä olevia tapahtumia ei voi muokata.'
-            }
-        }
+        // Tooltip is empty if the event is editable
+        let {eventIsEditable, eventEditabilityExplanation} = checkEventEditability(user, event)
 
         // Add necessary badges
         let draftClass = event.publication_status == constants.PUBLICATION_STATUS.DRAFT ? "event-page draft" : "event-page"
@@ -108,7 +88,7 @@ class EventPage extends React.Component {
             )
         }
 
-        const editEventButton = <Button raised onClick={e => this.editEvent(e)} disabled={!userCanEdit} style={buttonStyle} color="primary">Muokkaa tapahtumaa</Button>
+        const editEventButton = <Button raised onClick={e => this.editEvent(e)} disabled={!eventIsEditable} style={buttonStyle} color="primary">Muokkaa tapahtumaa</Button>
 
         if(event && event.name) {
             return (
@@ -123,11 +103,8 @@ class EventPage extends React.Component {
                     <div className="container">
                         <div className="col-sm-12">
                             <div className="col-sm-12 actions">
-                                {editEventTooltipTitle === '' &&
-                                    editEventButton
-                                }
-                                {editEventTooltipTitle !== '' &&
-                                    <Tooltip title={editEventTooltipTitle}>
+                                {eventIsEditable ? editEventButton :
+                                    <Tooltip title={eventEditabilityExplanation}>
                                         <span>{editEventButton}</span>
                                     </Tooltip>
                                 }


### PR DESCRIPTION
This is required because we want to transition production deployment to the already implemented organization model where a user may have several admin organizations.

Therefore, we want to support the current API code that has `admin_organizations` and `organization_memberships` keys in the `user` endpoint. This means we need to consistently check whether the user may edit the given event in the UI.

Of course, API takes care of permission checking, but we want the UI to be up to date with current API permissions model so the user knows why they may or may not edit given events.