### PR TITLE
change required price fields and fix isfree field on copied offers

### DIFF
--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -298,9 +298,8 @@ class FormFields extends React.Component {
                     </div>
                     <SideField>
                         <div className="tip">
-                            <p>Merkitse jos tapahtuma on maksuton tai lisää tapahtuman hinta tekstimuodossa (esim. 7€/5€).</p>
-                            <p>Kerro mahdollisesta ennakkoilmoittautumisesta tai anna lisätietoja esimerkiksi paikkavarauksista.</p>
-                            <p>Lisää mahdollinen linkki lipunmyyntiin tai ilmoittautumiseen.</p>
+                            <p>Merkitse onko tapahtuma maksuton. Syötä maksulliselle tapahtumalle hinta muodossa "5€".</p>
+                            <p>Jos tapahtumalla on useita hintoja, klikkaa Lisää uusi hintatieto ja merkitse kunkin hintaryhmän nimi (esim. Lapset) Hintatietojen kuvaus -kenttään.</p>
                         </div>
                     </SideField>
                 </div>

--- a/src/components/HelFormFields/HelOffersField.js
+++ b/src/components/HelFormFields/HelOffersField.js
@@ -24,9 +24,14 @@ class HelOffersField extends React.Component {
 
     constructor(props) {
       super(props);
+      let isFreeEvent = true
+      if (this.props.defaultValue && this.props.defaultValue.length > 0) {
+        isFreeEvent = false //we have length in defaultvalue array so we have prices -> not a free event.
+      }
+
       this.state = {
           values: this.props.defaultValue,
-          isFree: true
+          isFree: isFreeEvent
       };
   }
 

--- a/src/components/HelFormFields/NewOffer.js
+++ b/src/components/HelFormFields/NewOffer.js
@@ -80,8 +80,8 @@ class NewOffer extends React.Component {
         return (
             <div key={offerKey} className="offer-fields" style={{'position': 'relative'}}>
                 <label style={{position: 'relative'}}><ValidationPopover validationErrors={this.props.validationErrors} /></label>
+                <MultiLanguageField defaultValue={defaultValue.price} disabled={isFree} ref="price" label="event-price" languages={languages} onBlur={e => this.onBlur(e)} validationErrors={this.props.validationErrors['price']} index={this.props.offerKey} required={true} />
                 <MultiLanguageField defaultValue={defaultValue.info_url} ref="info_url" label="event-purchase-link" languages={languages} onBlur={e => this.onBlur(e)} validations={['isUrl']} validationErrors={this.props.validationErrors['info_url']} index={this.props.offerKey}/>
-                <MultiLanguageField defaultValue={defaultValue.price} disabled={isFree} ref="price" label="event-price" languages={languages} onBlur={e => this.onBlur(e)} validationErrors={this.props.validationErrors['price']} index={this.props.offerKey} />
                 <MultiLanguageField defaultValue={defaultValue.description} disabled={isFree} ref="description" label="event-price-info" languages={languages} multiLine={true} onBlur={e => this.onBlur(e)} validationErrors={this.props.validationErrors['offer_description']} index={this.props.offerKey} />
                 <Button
                     raised

--- a/src/validation/validator.js
+++ b/src/validation/validator.js
@@ -5,7 +5,6 @@ import validationFn from './validationRules'
 const draftValidations = {
     name: ['requiredMulti'],
     end_time: ['afterStartTime', 'inTheFuture'],
-    offer_description: ['hasPrice'],
     price: ['hasPrice'],
     short_description: ['shortString'],
     description: ['longString'],
@@ -22,7 +21,6 @@ const publicValidations = {
     hel_main: ['atLeastOne'],
     start_time: ['requiredString'], // Datetime is saved as ISO string
     end_time: ['afterStartTime', 'inTheFuture'],
-    offer_description: ['hasPrice'],
     price: ['hasPrice'],
     short_description: ['requiredMulti', 'requiredInContentLanguages', 'shortString'],
     description: ['requiredMulti', 'requiredInContentLanguages', 'longString'],


### PR DESCRIPTION
Resolves #278. 
Changed the required fields in the Price information-section ("Hintatiedot") so that only Price ("Hinta") will be set as mandatory. Hinta-field marked with an asterisk to indicate compulsory nature. Set the Hinta-field as the topmost field in its section. Changed the instruction-text of price fields.

Also fixed "is free" field initialization on copied events which have a price. 