### PR TITLE
Firefox event passing fix for event price

### DIFF
--- a/src/components/HelFormFields/MultiLanguageField.js
+++ b/src/components/HelFormFields/MultiLanguageField.js
@@ -56,7 +56,7 @@ class MultiLanguageField extends React.Component {
         }
 
         if(typeof this.props.onBlur === 'function') {
-            this.props.onBlur(event, this.getValue())
+            this.props.onBlur(e, this.getValue())
         }
     }
 


### PR DESCRIPTION
Fixes #301.
Firefox does not have DOM event attached to global window (like Chrome & IE) so we pass the React synthetic event to parent component blur handler (if parent blur handler is defined).
