### PR TITLE
[Fix] Fix multiline input field not having word-wrap break-word functionality 

### DIFF
--- a/src/components/HelFormFields/HelAutoComplete.js
+++ b/src/components/HelFormFields/HelAutoComplete.js
@@ -110,7 +110,6 @@ class HelAutoComplete extends React.Component {
                     </ControlLabel>
 
                     <FormControl
-                        type="text"
                         value={values.id ? values.id : ''}
                         ref="text"
                         disabled

--- a/src/components/HelFormFields/HelDatePicker.js
+++ b/src/components/HelFormFields/HelDatePicker.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react'
-import HelTextField from './HelTextField.js'
 import DatePicker from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
 import './HelDatePicker.scss'

--- a/src/components/HelFormFields/HelDateTimeField.js
+++ b/src/components/HelFormFields/HelDateTimeField.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react'
 import moment from 'moment'
 
-import HelTextField from './HelTextField'
 import HelDatePicker from './HelDatePicker'
 import HelTimePicker from './HelTimePicker'
 

--- a/src/components/HelFormFields/HelTextField.js
+++ b/src/components/HelFormFields/HelTextField.js
@@ -212,7 +212,7 @@ class HelTextField extends React.Component {
         if(this.props.type) {
             type = this.props.type
         } else {
-            type = this.props.multiLine ? 'textarea' : 'text'
+            type = this.props.multiLine ? 'textarea' : 'input'
         }
 
         return (
@@ -220,10 +220,9 @@ class HelTextField extends React.Component {
                 <div className={groupClassName}>
                     <ControlLabel className="hel-label relative">{label}</ControlLabel>
                     <FormControl
-                        type={type}
+                        componentClass={type}
                         value={this.state.value}
                         placeholder={this.props.placeholder}
-                        // bsStyle={this.validationState()} // TODO: Check glyph styling, now it shows success for empty values
                         inputRef={ref => this.inputRef = ref}
                         onChange={this.handleChange}
                         onBlur={this.handleBlur}

--- a/src/components/HelFormFields/HelTextField.js
+++ b/src/components/HelFormFields/HelTextField.js
@@ -2,7 +2,6 @@ import './HelTextField.scss'
 
 import PropTypes from 'prop-types';
 import React from 'react'
-import ReactDOM from 'react-dom'
 
 import {FormControl, ControlLabel, HelpBlock} from 'react-bootstrap'
 import {setData} from 'src/actions/editor.js'
@@ -124,8 +123,7 @@ class HelTextField extends React.Component {
 
     recalculateHeight() {
         if(this.props.multiLine) {
-            const input = ReactDOM.findDOMNode(this.inputRef)    // eslint-disable-line
-            input.style.height = input.scrollHeight + 2 + 'px';
+            this.inputRef.style.height = this.inputRef.scrollHeight + 2 + 'px';
         }
     }
 

--- a/src/components/HelFormFields/HelTextField.js
+++ b/src/components/HelFormFields/HelTextField.js
@@ -2,6 +2,8 @@ import './HelTextField.scss'
 
 import PropTypes from 'prop-types';
 import React from 'react'
+import ReactDOM from 'react-dom'
+
 import {FormControl, ControlLabel, HelpBlock} from 'react-bootstrap'
 import {setData} from 'src/actions/editor.js'
 
@@ -122,7 +124,8 @@ class HelTextField extends React.Component {
 
     recalculateHeight() {
         if(this.props.multiLine) {
-            this.inputRef.height = this.inputRef.scrollHeight + 2 + 'px';
+            const input = ReactDOM.findDOMNode(this.inputRef)    // eslint-disable-line
+            input.style.height = input.scrollHeight + 2 + 'px';
         }
     }
 

--- a/src/components/RecurringEvent/index.js
+++ b/src/components/RecurringEvent/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react'
-import HelTextField from 'src/components/HelFormFields/HelTextField.js'
+import HelTextField from 'src/components/HelFormFields/HelTextField'
 import RecurringDateRangePicker from './RecurringDateRangePicker'
 import RecurringTimePicker from './RecurringTimePicker'
 import {FormattedMessage} from 'react-intl'

--- a/src/components/SearchBar/index.js
+++ b/src/components/SearchBar/index.js
@@ -72,7 +72,6 @@ class SearchBar extends React.Component {
                             <FormattedMessage id="event-name-or-place"/>
                         </ControlLabel>
                         <FormControl
-                            type="text"
                             placeholder={this.props.intl.formatMessage({id: 'event-name-or-place'})}
                             onChange={ (e) => this.handleStringChange(e) }
                             ref="searchQueryInput"


### PR DESCRIPTION
React-bootstrap FormControl component no longer have and respect `type` props, now changed to `componentClass`

https://react-bootstrap.github.io/components/forms/#forms-props-form-control

Fix for #341 