### PR TITLE
validate and remove conflict data when copy event to new draft

### DIFF
--- a/src/actions/editor.js
+++ b/src/actions/editor.js
@@ -8,6 +8,7 @@ import {
     calculateSuperEventTime,
     combineSubEventsFromEditor,
 } from '../utils/formDataMapping'
+import {emptyField} from '../utils/helpers'
 
 import {push} from 'react-router-redux'
 import {setFlashMsg, confirmAction} from './app'
@@ -90,14 +91,24 @@ export function setLanguages(languages) {
  * @param  {obj} formValues     new form values to replace all existing values
  */
 export function replaceData(formValues) {
-    return (dispatch) => {
-    // Run validations
-        dispatch(validateFor(null))
-        dispatch(setValidationErrors({}))
+    return (dispatch, getState) => {
+        const {contentLanguages} = getState().editor
+        let formObject = formValues
+        const publicationStatus = formValues.publication_status || constants.PUBLICATION_STATUS.PUBLIC
 
+        // run the validation before copy to a draft
+        const validationErrors = doValidations(formValues, contentLanguages, publicationStatus)
+
+        // empty any field that has validation errors
+        keys(validationErrors).map(field => {
+            formObject = emptyField(formObject, field)
+        })
+
+        dispatch(validateFor(publicationStatus))
+        dispatch(setValidationErrors({}))
         dispatch({
             type: constants.EDITOR_REPLACEDATA,
-            values: formValues,
+            values: formObject,
         })
     }
 }

--- a/src/actions/editor.js
+++ b/src/actions/editor.js
@@ -4,6 +4,7 @@ import {includes, keys} from 'lodash';
 
 import constants from '../constants'
 import {
+    mapAPIDataToUIFormat,
     mapUIDataToAPIFormat,
     calculateSuperEventTime,
     combineSubEventsFromEditor,
@@ -90,20 +91,22 @@ export function setLanguages(languages) {
  * Replace all editor values
  * @param  {obj} formValues     new form values to replace all existing values
  */
-export function replaceData(formValues) {
+export function replaceData(formData) {
     return (dispatch, getState) => {
         const {contentLanguages} = getState().editor
-        let formObject = formValues
-        const publicationStatus = formValues.publication_status || constants.PUBLICATION_STATUS.PUBLIC
+        let formObject = mapAPIDataToUIFormat(formData)
+        const publicationStatus = formObject.publication_status || constants.PUBLICATION_STATUS.PUBLIC
 
         // run the validation before copy to a draft
-        const validationErrors = doValidations(formValues, contentLanguages, publicationStatus)
+        const validationErrors = doValidations(formObject, contentLanguages, publicationStatus)
 
-        // empty any field that has validation errors
+        // empty id, event_status, and any field that has validation errors
         keys(validationErrors).map(field => {
             formObject = emptyField(formObject, field)
         })
-
+        delete formObject.id
+        delete formObject.event_status
+        
         dispatch(validateFor(publicationStatus))
         dispatch(setValidationErrors({}))
         dispatch({

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,3 +1,5 @@
+import {isArray} from 'lodash';
+
 import CONSTANTS from '../constants'
 
 const {VALIDATION_RULES, CHARACTER_LIMIT} = CONSTANTS
@@ -43,4 +45,26 @@ export function textLimitValidator(value, limit) {
         }
     }
     return true
+}
+
+// set a property of an object to empty value based on its type
+export const emptyField = (object, field) => {
+    let value = object[field];
+    const fieldValueType = isArray(value) ? 'array' : typeof value;
+    
+    switch (fieldValueType) {
+        case 'array':
+            value = []
+            break
+        case 'object':
+            value = {}
+            break
+        case 'string':
+        case 'number':
+            value = ''
+            break
+        default:
+    }
+
+    return Object.assign({}, object, {[field]: value})
 }

--- a/src/views/Event/index.js
+++ b/src/views/Event/index.js
@@ -40,10 +40,7 @@ class EventPage extends React.Component {
     copyAsTemplate() {
         const {events:{event}, replaceData, routerPush} = this.props
         if(event) {
-            let formData = mapAPIDataToUIFormat(event)
-            formData.id = undefined
-            delete formData.id
-            replaceData(formData)
+            replaceData(event)
             routerPush(`/event/create/new`)
         }
     }
@@ -51,9 +48,7 @@ class EventPage extends React.Component {
     editEvent() {
         const {events:{event}, replaceData, routerPush} = this.props
         if(event) {
-            let formData = mapAPIDataToUIFormat(event)
-
-            replaceData(formData)            
+            replaceData(event)            
             routerPush(`/event/update/${event.id}`)
         }
     }
@@ -234,7 +229,7 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
     fetchEventDetails: (eventId, user) => dispatch(fetchEventDetailsAction(eventId, user)),
     routerPush: (url) => dispatch(push(url)),
-    replaceData: (formData, publication_status) => dispatch(replaceDataAction(formData, publication_status)),
+    replaceData: (event) => dispatch(replaceDataAction(event)),
     confirm: (msg, style, actionButtonLabel, data) => dispatch(confirmAction(msg, style, actionButtonLabel, data)),
     deleteEvent: (eventId, user) => dispatch(deleteEventAction(eventId, user)),
     cancelEvent: (eventId, user, values) => dispatch(cancelEventAction(eventId, user, values)),

--- a/src/views/Event/index.js
+++ b/src/views/Event/index.js
@@ -43,7 +43,6 @@ class EventPage extends React.Component {
             let formData = mapAPIDataToUIFormat(event)
             formData.id = undefined
             delete formData.id
-
             replaceData(formData)
             routerPush(`/event/create/new`)
         }
@@ -235,7 +234,7 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
     fetchEventDetails: (eventId, user) => dispatch(fetchEventDetailsAction(eventId, user)),
     routerPush: (url) => dispatch(push(url)),
-    replaceData: (formData) => dispatch(replaceDataAction(formData)),
+    replaceData: (formData, publication_status) => dispatch(replaceDataAction(formData, publication_status)),
     confirm: (msg, style, actionButtonLabel, data) => dispatch(confirmAction(msg, style, actionButtonLabel, data)),
     deleteEvent: (eventId, user) => dispatch(deleteEventAction(eventId, user)),
     cancelEvent: (eventId, user, values) => dispatch(cancelEventAction(eventId, user, values)),

--- a/src/views/Search/__snapshots__/Search.test.js.snap
+++ b/src/views/Search/__snapshots__/Search.test.js.snap
@@ -33,34 +33,32 @@ exports[`Search Snapshot should render view correctly 1`] = `
       <div
         className="hel-text-field"
       >
-        <div>
+        <div
+          className="react-datepicker-wrapper"
+        >
           <div
-            className="react-datepicker-wrapper"
+            className="react-datepicker__input-container"
           >
-            <div
-              className="react-datepicker__input-container"
-            >
-              <input
-                autoComplete={undefined}
-                autoFocus={undefined}
-                className=""
-                disabled={false}
-                id={undefined}
-                name="startDate"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                placeholder="pp.kk.vvvv"
-                readOnly={false}
-                required={undefined}
-                tabIndex={undefined}
-                title={undefined}
-                type="text"
-                value=""
-              />
-            </div>
+            <input
+              autoComplete={undefined}
+              autoFocus={undefined}
+              className=""
+              disabled={false}
+              id={undefined}
+              name="startDate"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              placeholder="pp.kk.vvvv"
+              readOnly={false}
+              required={undefined}
+              tabIndex={undefined}
+              title={undefined}
+              type="text"
+              value=""
+            />
           </div>
         </div>
       </div>
@@ -71,34 +69,32 @@ exports[`Search Snapshot should render view correctly 1`] = `
       <div
         className="hel-text-field"
       >
-        <div>
+        <div
+          className="react-datepicker-wrapper"
+        >
           <div
-            className="react-datepicker-wrapper"
+            className="react-datepicker__input-container"
           >
-            <div
-              className="react-datepicker__input-container"
-            >
-              <input
-                autoComplete={undefined}
-                autoFocus={undefined}
-                className=""
-                disabled={false}
-                id={undefined}
-                name="endDate"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                placeholder="pp.kk.vvvv"
-                readOnly={false}
-                required={undefined}
-                tabIndex={undefined}
-                title={undefined}
-                type="text"
-                value=""
-              />
-            </div>
+            <input
+              autoComplete={undefined}
+              autoFocus={undefined}
+              className=""
+              disabled={false}
+              id={undefined}
+              name="endDate"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              placeholder="pp.kk.vvvv"
+              readOnly={false}
+              required={undefined}
+              tabIndex={undefined}
+              title={undefined}
+              type="text"
+              value=""
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fix for issue #311 and #279. Notices:
- Now before copy from an existing event to a new draft, the existing event data will be validated.
- After validating, all invalid fields will be emptied based on their types: `array -> []`, `object -> {}`, `string -> ''` ...etc
- Fields with tricky types (if there is any) like `null`, `undefined`, `boolean`... should be left unchanged.

There is no validation for `location` and `keywords` in UI. Maybe these should to a later separate issue.

Signed-off-by: Thanh Do <thanh.do@digia.com>