### PR TITLE
Fix/374 error indicator addtional datetime

### DIFF
--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -100,6 +100,9 @@ class FormFields extends React.Component {
     }
 
     generateNewEventFields(events) {
+        const {validationErrors} = this.props.editor;
+        const subEventErrors = validationErrors.sub_events || []
+
         let newEvents = []
         for (const key in events) {
             if (events.hasOwnProperty(key)) {
@@ -108,6 +111,7 @@ class FormFields extends React.Component {
                         key={key}
                         eventKey={key}
                         event={events[key]}
+                        errors={subEventErrors[key] || {}}
                     />
                 )
             }

--- a/src/components/HelFormFields/NewEvent.js
+++ b/src/components/HelFormFields/NewEvent.js
@@ -16,6 +16,7 @@ class NewEvent extends React.Component {
         this.context.dispatch(deleteSubEvent(this.props.eventKey))
     }
     render() {
+        const {eventKey, errors} = this.props;
         const buttonStyles = {
             width: '42px',
             minWidth: '42px',
@@ -33,8 +34,8 @@ class NewEvent extends React.Component {
                                 ref="start_time"
                                 name="start_time"
                                 label="event-starting-datetime"
-                                //defaultValue={this.props.event.start_time}
-                                eventKey={this.props.eventKey}
+                                eventKey={eventKey}
+                                validationErrors={errors['start_time']}
                             />
                         </div>
                         <div className="col-xs-12 col-md-6">
@@ -42,8 +43,8 @@ class NewEvent extends React.Component {
                                 ref="end_time"
                                 name="end_time"
                                 label="event-ending-datetime"
-                                //defaultValue={this.props.event.end_time}
-                                eventKey={this.props.eventKey}
+                                eventKey={eventKey}
+                                validationErrors={errors['end_time']}
                             />
                         </div>
                         <Button
@@ -61,6 +62,7 @@ class NewEvent extends React.Component {
 NewEvent.propTypes = {
     event: PropTypes.object.isRequired,
     eventKey: PropTypes.string.isRequired,
+    errors: PropTypes.object,
 }
 
 export default NewEvent;

--- a/src/reducers/editor.js
+++ b/src/reducers/editor.js
@@ -107,15 +107,27 @@ function update(state = initialState, action) {
     }
 
     if (action.type === constants.EDITOR_UPDATE_SUB_EVENT) {
-        return updater(state, {
-            values: {
-                sub_events: {
-                    [action.eventKey]: {
-                        [action.property]: {$set: action.value},
-                    },
+
+        const newValues = updater(state.values, {
+            sub_events: {
+                [action.eventKey]: {
+                    [action.property]: {$set: action.value},
                 },
             },
         })
+        
+        let validationErrors = Object.assign({}, state.validationErrors)
+        // If there are validation errors in sub_events, check if they are fixed
+        if (state.validationErrors.sub_events) {
+            validationErrors = doValidations(newValues, state.contentLanguages, state.validateFor || constants.PUBLICATION_STATUS.PUBLIC)
+        }
+
+        const x = Object.assign({}, state, {
+            values: newValues,
+            validationErrors,
+        })
+        console.log(x, newValues, validationErrors)
+        return x
     }
 
     if (action.type === constants.EDITOR_DELETE_SUB_EVENT) {

--- a/src/validation/validator.js
+++ b/src/validation/validator.js
@@ -78,18 +78,19 @@ function runValidationWithSettings(values, languages, settings) {
 
         // validate sub events
         if (key === 'sub_events') {
-            each(values['sub_events'], (subEvent) => {
+            each(values['sub_events'], (subEvent, eventKey) => {
                 const subEventError = runValidationWithSettings(subEvent, languages, settings.sub_events)
-                errors.push(
-                    isEmpty(subEventError) ? null : subEventError
-                )
+                const error = isEmpty(subEventError) ? null : subEventError
+                errors[eventKey] = error
             })
         } else {
             errors = validateEventObject(validations, valuesWithLanguages, key)
         }
 
-        // Remove nulls
-        remove(errors, i => i === null)
+        // Remove nulls, except for sub_events
+        if (key !== 'sub_events') {
+            remove(errors, i => i === null)
+        }
 
         obj[key] = errors
     })


### PR DESCRIPTION
Resolve issue #374 :
- errors for each additional datetime are now displayed separately
- the error link ("Siirry virheeseen") can now scroll the page to corresponding errors in additional datetime/sub events