### PR TITLE
fix non-displayed addtional datetimes when use recurring tool

### DIFF
--- a/src/components/HelFormFields/NewEvent.js
+++ b/src/components/HelFormFields/NewEvent.js
@@ -33,7 +33,7 @@ class NewEvent extends React.Component {
                                 ref="start_time"
                                 name="start_time"
                                 label="event-starting-datetime"
-                                //defaultValue={this.props.event.start_time}
+                                defaultValue={this.props.event.start_time}
                                 eventKey={this.props.eventKey}
                             />
                         </div>
@@ -42,7 +42,7 @@ class NewEvent extends React.Component {
                                 ref="end_time"
                                 name="end_time"
                                 label="event-ending-datetime"
-                                //defaultValue={this.props.event.end_time}
+                                defaultValue={this.props.event.end_time}
                                 eventKey={this.props.eventKey}
                             />
                         </div>


### PR DESCRIPTION
Fix #373 .
Turned out that, this [PR](https://github.com/City-of-Helsinki/linkedevents-ui/pull/361) for issue #312 only removes the default display of additional datetimes without changing the initial values of corresponding datetimes in the store. Since now the new datetime is generated with empty value by default, we can put the UI default display for datetime fields back again.

Signed-off-by: Thanh Do <thanh.do@digia.com>