### PR TITLE
fix empty end time field cause moment to use current time

### DIFF
--- a/src/components/RecurringEvent/index.js
+++ b/src/components/RecurringEvent/index.js
@@ -5,7 +5,7 @@ import RecurringDateRangePicker from './RecurringDateRangePicker'
 import RecurringTimePicker from './RecurringTimePicker'
 import {FormattedMessage} from 'react-intl'
 import moment from 'moment'
-import {some, values, forEach} from 'lodash'
+import {some, values, forEach, isEmpty} from 'lodash' 
 
 import DayCheckbox from './DayCheckbox'
 // Material-ui Icons
@@ -14,7 +14,7 @@ import {Button as MaterialButton} from 'material-ui'
 import {Grid, Row, Col, ControlLabel, Button} from 'react-bootstrap'
 
 import {connect} from 'react-redux'
-import {setEventData, sortSubEvents} from 'src/actions/editor'
+import {setEventData, sortSubEvents, setData} from 'src/actions/editor'
 
 import validationRules from 'src/validation/validationRules'
 import ValidationPopover from 'src/components/ValidationPopover'
@@ -46,6 +46,8 @@ class RecurringEvent extends React.Component {
         this.onCheckboxChange = this.onCheckboxChange.bind(this)
         this.weekIntervalChange = this.weekIntervalChange.bind(this)
         this.onTimeChange = this.onTimeChange.bind(this)
+
+        const {values: {start_time, end_time}} = this.props;
         this.state = {
             weekInterval: 1,
             daysSelected: {
@@ -57,10 +59,10 @@ class RecurringEvent extends React.Component {
                 saturday: false,
                 sunday: false,
             },
-            recurringStartDate: moment(this.props.values.start_time),
-            recurringStartTime: moment(this.props.values.start_time).format('HH:mm'),
-            recurringEndDate: moment(this.props.values.end_time).add(2, 'weeks'),
-            recurringEndTime: moment(this.props.values.end_time).format('HH:mm'),
+            recurringStartDate: isEmpty(start_time) ? '' : moment(this.props.values.start_time),
+            recurringStartTime: isEmpty(start_time) ? '' : moment(this.props.values.start_time).format('HH:mm'),
+            recurringEndDate: isEmpty(end_time) ? '' : moment(this.props.values.end_time).add(2, 'weeks'),
+            recurringEndTime: isEmpty(end_time) ? '' : moment(this.props.values.end_time).format('HH:mm'),
             errors: {
                 afterStartTime: false,
                 atLeastOneIsTrue: false,
@@ -131,7 +133,10 @@ class RecurringEvent extends React.Component {
                     saturday: 6,
                     sunday: 7,
                 }
-                const eventLength = moment(this.props.values.start_time).diff(this.props.values.end_time, 'minutes') * -1
+                let eventLength
+                if (!isEmpty(recurringEndTime)) {
+                    eventLength = moment(recurringEndTime).diff(recurringStartTime, 'minutes')
+                }
                 let recurringStartTime = Object.assign({}, {full: this.state.recurringStartTime}, {hours: ''}, {minutes: ''})
                 switch(recurringStartTime.full.length) {
                     case 2:
@@ -164,11 +169,14 @@ class RecurringEvent extends React.Component {
                                 const key = Object.keys(this.props.values.sub_events).length + count
                                 count += 1
                                 const startTime = moment().isoWeekday(day + i * interval).hours(recurringStartTime.hours).minutes(recurringStartTime.minutes)
-                                let endTime = Object.assign({}, startTime)
-                                endTime = moment(endTime).add(eventLength, 'minutes').hours(recurringEndTime.hours).minutes(recurringEndTime.minutes)
+                                let endTime
+                                if (!isEmpty(rules.recurringEndTime)) {
+                                    endTime = Object.assign({}, startTime)
+                                    endTime = moment(endTime).add(eventLength, 'minutes').hours(recurringEndTime.hours).minutes(recurringEndTime.minutes)
+                                }
                                 obj[key] = {
                                     start_time: moment.tz(startTime, 'Europe/Helsinki').utc().toISOString(),
-                                    end_time: moment.tz(endTime, 'Europe/Helsinki').utc().toISOString(),
+                                    end_time: endTime ? moment.tz(endTime, 'Europe/Helsinki').utc().toISOString() : undefined,
                                 }
                                 this.context.dispatch(setEventData(obj, key))
                                 this.props.toggle()


### PR DESCRIPTION
Resolved #372 

Note:
- the datetime user entered before generating recurring events with recurring tools will not be updated accordingly since it's unnecessarily complicated. Example below.

After using recurring tool:
<img width="300" alt="screen shot 2018-12-11 at 10 26 52" src="https://user-images.githubusercontent.com/25722607/49787472-7c917d80-fd2f-11e8-92d5-ee17e10fdffa.png">


Signed-off-by: Thanh Do <thanh.do@digia.com>