### PR TITLE
Fix delete button on event preview page

### DIFF
--- a/src/views/Event/index.js
+++ b/src/views/Event/index.js
@@ -5,6 +5,7 @@ import {connect} from 'react-redux'
 import EventDetails from 'src/components/EventDetails'
 import moment from 'moment'
 import PropTypes from 'prop-types'
+import {isEmpty} from 'lodash'
 
 import {FormattedMessage, injectIntl, intlShape} from 'react-intl'
 
@@ -16,12 +17,15 @@ import {fetchEventDetails as fetchEventDetailsAction} from 'src/actions/events.j
 import {
     replaceData as replaceDataAction,
     deleteEvent as deleteEventAction, 
-    cancelEvent as cancelEventAction, 
+    cancelEvent as cancelEventAction,
+    deleteSubEvent as deleteSubEventAction, 
 } from 'src/actions/editor.js'
+import {fetchSubEvents as fetchSubEventsAction} from 'src/actions/subEvents'
 
 import {
     confirmAction, 
-    clearFlashMsg as clearFlashMsgAction} from 'src/actions/app.js'
+    clearFlashMsg as clearFlashMsgAction,
+} from 'src/actions/app.js'
 
 import {getStringWithLocale} from 'src/utils/locale'
 import {mapAPIDataToUIFormat} from 'src/utils/formDataMapping.js'
@@ -32,9 +36,10 @@ import constants from 'src/constants'
 class EventPage extends React.Component {
 
     UNSAFE_componentWillMount() {
-        const {match, fetchEventDetails, user} = this.props
+        const {match, fetchEventDetails, user, events: {event}, fetchSubEvents} = this.props
 
         fetchEventDetails(match.params.eventId, user)
+        fetchSubEvents(this.props.match.params.eventId, user)
     }
 
     copyAsTemplate() {
@@ -99,12 +104,13 @@ class EventPage extends React.Component {
     }
 
     deleteEvents() {
-        if (this.props.subEvents.items.length) {
-            for (const subEvent of this.props.subEvents.items) {
-                this.deleteSubEvent(subEvent.id, this.props.user)
+        const {subEvents, deleteSubEvent, user, deleteEvent} = this.props;
+        if (subEvents.items.length) {
+            for (const subEvent of subEvents.items) {
+                deleteSubEvent(subEvent.id, user)
             }
         }
-        return this.props.deleteEvent(this.props.match.params.eventId, this.props.user)
+        return deleteEvent(this.props.match.params.eventId, user)
     }
 
     getWarningMarkup() {
@@ -217,6 +223,8 @@ EventPage.propTypes = {
     deleteEvent: PropTypes.func,
     editor: PropTypes.object,
     intl: intlShape.isRequired,
+    fetchSubEvents: PropTypes.func,
+    deleteSubEvent: PropTypes.func,
 }
 
 const mapStateToProps = (state) => ({
@@ -233,6 +241,8 @@ const mapDispatchToProps = (dispatch) => ({
     confirm: (msg, style, actionButtonLabel, data) => dispatch(confirmAction(msg, style, actionButtonLabel, data)),
     deleteEvent: (eventId, user) => dispatch(deleteEventAction(eventId, user)),
     cancelEvent: (eventId, user, values) => dispatch(cancelEventAction(eventId, user, values)),
+    fetchSubEvents: (user, superEventId) => dispatch(fetchSubEventsAction(user, superEventId)),
+    deleteSubEvent: (event) => dispatch(deleteSubEventAction(event)),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(EventPage))


### PR DESCRIPTION
Using the delete button on event preview page doesn't delete also the related sub events. Fixed. 

Signed-off-by: Thanh Do <thanh.do@digia.com>