### PR TITLE
add mockdate to pinpoint fixed current time for relative dates testing

### DIFF
--- a/__mocks__/testMocks.js
+++ b/__mocks__/testMocks.js
@@ -1,0 +1,23 @@
+export function mockCurrentTime(mockTime) {
+    const RealDate = Date
+
+    class MockDate extends RealDate {
+        constructor(values) {
+            super()
+            if (values) {
+                return new RealDate(values)
+            } else {
+                return new RealDate(mockTime)
+            }
+        }
+
+        static now() {
+            return (new RealDate(mockTime)).getTime()
+        }
+    }
+    global.Date = MockDate
+}
+
+export const resetMockDate = () => {
+    global.Date = window.Date
+}

--- a/src/views/EventListing/EventListing.test.js
+++ b/src/views/EventListing/EventListing.test.js
@@ -7,6 +7,7 @@ import renderer from 'react-test-renderer'
 import testReduxIntWrapper from '../../../__mocks__/testReduxIntWrapper'
 import ConnectedEventListing, {EventListing} from './index'
 import {mockUserEvents} from '__mocks__/mockData';
+import {mockCurrentTime, resetMockDate} from '../../../__mocks__/testMocks';
 
 const mockStore = configureStore([thunk])
 const initialStore = {
@@ -41,6 +42,14 @@ const initialStore = {
 
 describe('EventListing Snapshot', () => {
     let store;
+
+    beforeEach(() => {
+        mockCurrentTime('2018-11-10T12:00:00z')
+    })
+
+    afterEach(() => {
+        resetMockDate()
+    })
 
     it('should render view by default', () => {
         const componentProps = {

--- a/src/views/EventListing/__snapshots__/EventListing.test.js.snap
+++ b/src/views/EventListing/__snapshots__/EventListing.test.js.snap
@@ -239,7 +239,7 @@ exports[`EventListing Snapshot should render view correctly 1`] = `
               className="MuiTableCell-root-7 MuiTableCell-paddingDefault-12 MuiTableCell-typeBody-10"
             >
               <span>
-                11 kuukautta sitten
+                10 kuukautta sitten
               </span>
             </td>
           </tr>
@@ -278,7 +278,7 @@ exports[`EventListing Snapshot should render view correctly 1`] = `
               className="MuiTableCell-root-7 MuiTableCell-paddingDefault-12 MuiTableCell-typeBody-10"
             >
               <span>
-                11 kuukautta sitten
+                10 kuukautta sitten
               </span>
             </td>
           </tr>


### PR DESCRIPTION
Notes:
- use mock date object instead of `window.Date` for test case require relative dates calculation
- mock date can use any date as current time. For test cases EventList component, current time is pinpointed to 11/2018