### PR TITLE
re-position buttons for elements in offers and events section

### DIFF
--- a/src/components/HelFormFields/NewEvent.js
+++ b/src/components/HelFormFields/NewEvent.js
@@ -22,8 +22,8 @@ class NewEvent extends React.Component {
             minWidth: '42px',
             height: '36px',
             position: 'absolute',
-            left: '-30px',
-            top: '25px',
+            left: '-55px',
+            top: '2rem',
         }
         return (
             <div className="new-events">

--- a/src/components/HelFormFields/NewOffer.js
+++ b/src/components/HelFormFields/NewOffer.js
@@ -87,7 +87,7 @@ class NewOffer extends React.Component {
             height: '36px',
             position: 'absolute',
             left: '-55px',
-            top: '0',
+            top: '2rem',
         }
         return (
             <div key={offerKey} className="offer-fields" style={{'position': 'relative'}}>


### PR DESCRIPTION
re-positioning delete button in events and offers form section:
- vertically align with top of the element
- got the right padding correctly (resolved overlap)

Signed-off-by: Thanh Do <thanh.do@digia.com>