### PR TITLE
increment suggested starting datetime in recurring tool

### DIFF
--- a/src/components/RecurringEvent/index.js
+++ b/src/components/RecurringEvent/index.js
@@ -59,7 +59,7 @@ class RecurringEvent extends React.Component {
                 saturday: false,
                 sunday: false,
             },
-            recurringStartDate: isEmpty(start_time) ? moment(null) : moment(this.props.values.start_time),
+            recurringStartDate: isEmpty(start_time) ? moment(null) : moment(this.props.values.start_time).add(1, 'weeks'),
             recurringStartTime: isEmpty(start_time) ? '' : moment(this.props.values.start_time).format('HH:mm'),
             recurringEndDate: isEmpty(end_time) ? moment(null) : moment(this.props.values.end_time).add(2, 'weeks'),
             recurringEndTime: isEmpty(end_time) ? '' : moment(this.props.values.end_time).format('HH:mm'),


### PR DESCRIPTION
- if user has some initial input for datetime in event form, the recurring tool should suggested initial starting time as 1 week from user's initial input
- if user has no initial input for datetime, the recurring tool should have empty suggestion for its datetime range

Signed-off-by: Thanh Do <thanh.do@digia.com>