### PR TITLE
Enhancement/380 events series mass cancelling

### DIFF
--- a/src/actions/editor.js
+++ b/src/actions/editor.js
@@ -15,6 +15,7 @@ import {push} from 'react-router-redux'
 import {setFlashMsg, confirmAction} from './app'
 
 import {doValidations} from 'src/validation/validator.js'
+import {fetchSubEventsForSuper} from './subEvents';
 
 /**
  * Set editor form data
@@ -536,6 +537,14 @@ export function cancelEvent(eventId, user, values) {
                     if (isSuperEvent) {
                         const subEvents = getState().subEvents.items;
                         subEvents.forEach(event => dispatch(cancelEvent(event.id, user, event)));
+                        dispatch(fetchSubEventsForSuper(json.id));
+                    }
+                    const allSuperEventIds = Object.keys(getState().subEvents.bySuperEventId);
+                    const cancelledEventSuperId = json.super_event
+                        && allSuperEventIds.find(id => json.super_event['@id'].includes(id));
+                    // re-fetch sub events data after cancelling non-super event
+                    if (cancelledEventSuperId) {
+                        dispatch(fetchSubEventsForSuper(cancelledEventSuperId));
                     }
                     dispatch(sendDataComplete(json, actionName));
                 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -196,8 +196,8 @@
 
     "editor-delete-subevents-warning": "The following subevents will be deleted:",
     "editor-delete-warning": "WARNING: This action will delete the event permanently. You may cancel or postpone the event if needed.",
-    "editor-cancel-subevents-warning": "The following subevents will be deleted:",
-    "editor-cancel-warning": "WARNING: This action will delete the event permanently. You may cancel or postpone the event if needed.",
+    "editor-cancel-subevents-warning": "The following subevents will also be cancelled:",
+    "editor-cancel-warning": "WARNING: This action will cancel the event. You can also delete an event, if it was erroneously entered.",
     "editor-sentinel-alert": "You can view the form, but you don't have the permission to publish or edit events. You are not logged in or your login has expired.",
 
     "editor-tip-time-start": "Enter the start date of the event and also the start time if the event starts at a specific time.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -196,6 +196,8 @@
 
     "editor-delete-subevents-warning": "The following subevents will be deleted:",
     "editor-delete-warning": "WARNING: This action will delete the event permanently. You may cancel or postpone the event if needed.",
+    "editor-cancel-subevents-warning": "The following subevents will be deleted:",
+    "editor-cancel-warning": "WARNING: This action will delete the event permanently. You may cancel or postpone the event if needed.",
     "editor-sentinel-alert": "You can view the form, but you don't have the permission to publish or edit events. You are not logged in or your login has expired.",
 
     "editor-tip-time-start": "Enter the start date of the event and also the start time if the event starts at a specific time.",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -195,8 +195,8 @@
 
     "editor-delete-subevents-warning": "Poistaessasi tämän tapahtuman myös seuraavat alitapahtumat poistetaan:",
     "editor-delete-warning": "VAROITUS: Tämä toiminto poistaa tapahtuman lopullisesti. Voit tarvittaessa myös perua tapahtuman tai lykätä sitä.",
-    "editor-cancel-subevents-warning": "Poistaessasi tämän tapahtuman myös seuraavat alitapahtumat poistetaan:",
-    "editor-cancel-warning": "VAROITUS: Tämä toiminto poistaa tapahtuman lopullisesti. Voit tarvittaessa myös perua tapahtuman tai lykätä sitä.",
+    "editor-cancel-subevents-warning": "Samalla myös seuraavat alitapahtumat peruutetaan:",
+    "editor-cancel-warning": "VAROITUS: Tämä toiminto peruuttaa tapahtuman. Voit myös poistaa sellaisen tapahtuman, jonka syötit vahingossa.",
     "editor-sentinel-alert": "Voit katsella lomaketta, mutta sinulla ei ole oikeuksia julkaista tai muokata tapahtumia. Et ole kirjautunut sisään tai kirjautumisesi on vanhentunut.",
     
     "editor-tip-time-start": "Kirjoita tapahtuman alkamispäivä ja myös alkamisaika, jos tapahtuma alkaa tiettyyn kellonaikaan.",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -195,6 +195,8 @@
 
     "editor-delete-subevents-warning": "Poistaessasi tämän tapahtuman myös seuraavat alitapahtumat poistetaan:",
     "editor-delete-warning": "VAROITUS: Tämä toiminto poistaa tapahtuman lopullisesti. Voit tarvittaessa myös perua tapahtuman tai lykätä sitä.",
+    "editor-cancel-subevents-warning": "Poistaessasi tämän tapahtuman myös seuraavat alitapahtumat poistetaan:",
+    "editor-cancel-warning": "VAROITUS: Tämä toiminto poistaa tapahtuman lopullisesti. Voit tarvittaessa myös perua tapahtuman tai lykätä sitä.",
     "editor-sentinel-alert": "Voit katsella lomaketta, mutta sinulla ei ole oikeuksia julkaista tai muokata tapahtumia. Et ole kirjautunut sisään tai kirjautumisesi on vanhentunut.",
     
     "editor-tip-time-start": "Kirjoita tapahtuman alkamispäivä ja myös alkamisaika, jos tapahtuma alkaa tiettyyn kellonaikaan.",

--- a/src/views/Editor/index.js
+++ b/src/views/Editor/index.js
@@ -36,7 +36,7 @@ var EXT_LINK_NO_LANGUAGE = 'fi'
 var sentinel = true;
 
 import FormFields from '../../components/FormFields'
-import {mapAPIDataToUIFormat} from '../../utils/formDataMapping';
+import {mapAPIDataToUIFormat, mapUIDataToAPIFormat} from '../../utils/formDataMapping';
 
 export class EditorPage extends React.Component {
     constructor(props) {
@@ -249,29 +249,19 @@ export class EditorPage extends React.Component {
     }
 
     confirmCancel() {
-    // TODO: maybe do a decorator for confirmable actions etc...?
+        const {user, editor,cancelEvent} = this.props;
+        const eventId = this.props.match.params.eventId;
+        // TODO: maybe do a decorator for confirmable actions etc...?
         this.props.confirm(
             'confirm-cancel',
             'warning',
             'cancel-events',
             {
-                action: () => this.cancelEvents(),
+                action: () => cancelEvent(eventId, user, mapUIDataToAPIFormat(editor.values)),
                 additionalMsg: getStringWithLocale(this.props, 'editor.values.name', 'fi'),
                 // additionalMarkup: ' ',
             }
         )
-    }
-
-    // cancel all events in a series of recurring events
-    cancelEvents = () => {
-        const {user, editor, subEvents, cancelEvent} = this.props;
-        const superEventId = this.props.match.params.eventId;
-        if (subEvents.items.length) {
-            for (const event of subEvents.items) {
-                cancelEvent(event.id, user, mapAPIDataToUIFormat(event));
-            }
-        }
-        cancelEvent(superEventId, user, editor.values);
     }
 
     render() {

--- a/src/views/Editor/index.js
+++ b/src/views/Editor/index.js
@@ -36,6 +36,7 @@ var EXT_LINK_NO_LANGUAGE = 'fi'
 var sentinel = true;
 
 import FormFields from '../../components/FormFields'
+import {mapAPIDataToUIFormat} from '../../utils/formDataMapping';
 
 export class EditorPage extends React.Component {
     constructor(props) {
@@ -264,10 +265,24 @@ export class EditorPage extends React.Component {
             'warning',
             'cancel-events',
             {
-                action: e => this.props.cancelEvent(this.props.match.params.eventId, this.props.user, this.props.editor.values),
+                action: () => this.cancelEvents(),
                 additionalMsg: getStringWithLocale(this.props, 'editor.values.name', 'fi'),
+                // additionalMarkup: ' ',
             }
         )
+    }
+
+    // cancel all events in a series of recurring events
+    cancelEvents = () => {
+        const {user, editor, subEvents, cancelEvent} = this.props;
+        const superEventId = this.props.match.params.eventId;
+        if (subEvents.items.length) {
+            for (const event of subEvents.items) {
+                cancelEvent(event.id, user, mapAPIDataToUIFormat(event));
+                console.log('as')
+            }
+        }
+        cancelEvent(superEventId, user, editor.values);
     }
 
     render() {

--- a/src/views/Editor/index.js
+++ b/src/views/Editor/index.js
@@ -232,30 +232,20 @@ export class EditorPage extends React.Component {
     }
 
     confirmDelete() {
-    // TODO: maybe do a decorator for confirmable actions etc...?
+        // TODO: maybe do a decorator for confirmable actions etc...?
+        const eventId = this.props.match.params.eventId;
+        const {user, deleteEvent, editor} = this.props;
+
         this.props.confirm(
             'confirm-delete',
             'warning',
             'delete-events',
             {
-                action: () => this.deleteEvents(),
+                action: () => deleteEvent(eventId, user, editor.values),
                 additionalMsg: getStringWithLocale(this.props, 'editor.values.name', 'fi'),
                 additionalMarkup: this.getWarningMarkup(),
             }
         )
-    }
-
-    deleteEvents() {
-        if (this.props.subEvents.items.length) {
-            for (const subEvent of this.props.subEvents.items) {
-                this.deleteSubEvent(subEvent.id, this.props.user)
-            }
-        }
-        return this.props.deleteEvent(this.props.match.params.eventId, this.props.user)
-    }
-
-    deleteSubEvent(eventId) {
-        return this.props.deleteEvent(eventId, this.props.user)
     }
 
     confirmCancel() {
@@ -279,7 +269,6 @@ export class EditorPage extends React.Component {
         if (subEvents.items.length) {
             for (const event of subEvents.items) {
                 cancelEvent(event.id, user, mapAPIDataToUIFormat(event));
-                console.log('as')
             }
         }
         cancelEvent(superEventId, user, editor.values);
@@ -360,7 +349,7 @@ const mapDispatchToProps = (dispatch) => ({
     sendData: (updateExisting, publicationStatus) => 
         dispatch(sendDataAction(updateExisting, publicationStatus)),
     confirm: (msg, style, actionButtonLabel, data) => dispatch(confirmAction(msg, style, actionButtonLabel, data)),
-    deleteEvent: (eventId, user) => dispatch(deleteEventAction(eventId, user)),
+    deleteEvent: (eventId, user, values) => dispatch(deleteEventAction(eventId, user, values)),
     cancelEvent: (eventId, user, values) => dispatch(cancelEventAction(eventId, user, values)),
 })
 

--- a/src/views/Editor/index.js
+++ b/src/views/Editor/index.js
@@ -206,15 +206,16 @@ export class EditorPage extends React.Component {
     // console.log(event)
     }
 
-    getWarningMarkup() {
-        let warningText = this.props.intl.formatMessage({id: 'editor-delete-warning'}) + '<br/>'
+    // action: either 'delete' or 'cancel'
+    getWarningMarkup(action) {
+        let warningText = this.props.intl.formatMessage({id: `editor-${action}-warning`}) + '<br/>'
         let subEventWarning = ''
         if (this.props.subEvents.items && this.props.subEvents.items.length) {
             const subEventNames = []
             for (const subEvent of this.props.subEvents.items) {
                 subEventNames.push(`</br><strong>${subEvent.name.fi}</strong> (${moment(subEvent.start_time).format('DD.MM.YYYY')})`)
             }
-            subEventWarning = `</br>${this.props.intl.formatMessage({id: 'editor-delete-subevents-warning'})}</br>${subEventNames}`
+            subEventWarning = `</br>${this.props.intl.formatMessage({id: `editor-${action}-subevents-warning`})}</br>${subEventNames}`
         }
         return warningText + subEventWarning
     }
@@ -243,7 +244,7 @@ export class EditorPage extends React.Component {
             {
                 action: () => deleteEvent(eventId, user, editor.values),
                 additionalMsg: getStringWithLocale(this.props, 'editor.values.name', 'fi'),
-                additionalMarkup: this.getWarningMarkup(),
+                additionalMarkup: this.getWarningMarkup('delete'),
             }
         )
     }
@@ -259,7 +260,7 @@ export class EditorPage extends React.Component {
             {
                 action: () => cancelEvent(eventId, user, mapUIDataToAPIFormat(editor.values)),
                 additionalMsg: getStringWithLocale(this.props, 'editor.values.name', 'fi'),
-                // additionalMarkup: ' ',
+                additionalMarkup: this.getWarningMarkup('cancel'),
             }
         )
     }

--- a/src/views/Event/index.js
+++ b/src/views/Event/index.js
@@ -84,7 +84,7 @@ class EventPage extends React.Component {
             {
                 action: () => cancelEvent(eventId, user, events.event),
                 additionalMsg: getStringWithLocale(this.props, 'editor.values.name', 'fi'),
-                additionalMarkup: this.getWarningMarkup(),
+                additionalMarkup: this.getWarningMarkup('cancel'),
             }
         )
     }
@@ -101,20 +101,21 @@ class EventPage extends React.Component {
             {
                 action: () => deleteEvent(eventId, user, events.event),
                 additionalMsg: getStringWithLocale(this.props, 'editor.values.name', 'fi'),
-                additionalMarkup: this.getWarningMarkup(),
+                additionalMarkup: this.getWarningMarkup('delete'),
             }
         )
     }
 
-    getWarningMarkup() {
-        let warningText = this.props.intl.formatMessage({id: 'editor-delete-warning'}) + '<br/>'
+    // action: either 'delete' or 'cancel'
+    getWarningMarkup(action) {
+        let warningText = this.props.intl.formatMessage({id: `editor-${action}-warning`}) + '<br/>'
         let subEventWarning = ''
         if (this.props.subEvents.items && this.props.subEvents.items.length) {
             const subEventNames = []
             for (const subEvent of this.props.subEvents.items) {
                 subEventNames.push(`</br><strong>${subEvent.name.fi}</strong> (${moment(subEvent.start_time).format('DD.MM.YYYY')})`)
             }
-            subEventWarning = `</br>${this.props.intl.formatMessage({id: 'editor-delete-subevents-warning'})}</br>${subEventNames}`
+            subEventWarning = `</br>${this.props.intl.formatMessage({id: `editor-${action}-subevents-warning`})}</br>${subEventNames}`
         }
         return warningText + subEventWarning
     }

--- a/src/views/Event/index.js
+++ b/src/views/Event/index.js
@@ -74,13 +74,15 @@ class EventPage extends React.Component {
     }
 
     confirmCancel() {
+        const {user, events, cancelEvent} = this.props;
+        const eventId = this.props.match.params.eventId;
         // TODO: maybe do a decorator for confirmable actions etc...?
         this.props.confirm(
             'confirm-cancel',
             'warning',
             'cancel-events',
             {
-                action: e => this.props.cancelEvent(this.props.match.params.eventId, this.props.user, mapAPIDataToUIFormat(this.props.events.event)),
+                action: () => cancelEvent(eventId, user, events.event),
                 additionalMsg: getStringWithLocale(this.props, 'editor.values.name', 'fi'),
                 additionalMarkup: this.getWarningMarkup(),
             }

--- a/src/views/Event/index.js
+++ b/src/views/Event/index.js
@@ -89,26 +89,19 @@ class EventPage extends React.Component {
 
     confirmDelete() {
         // TODO: maybe do a decorator for confirmable actions etc...?
+        const eventId = this.props.match.params.eventId;
+        const {user, deleteEvent, events} = this.props;
+
         this.props.confirm(
             'confirm-delete',
             'warning',
             'delete-events',
             {
-                action: () => this.deleteEvents(),
+                action: () => deleteEvent(eventId, user, events.event),
                 additionalMsg: getStringWithLocale(this.props, 'editor.values.name', 'fi'),
                 additionalMarkup: this.getWarningMarkup(),
             }
         )
-    }
-
-    deleteEvents() {
-        const {subEvents, user, deleteEvent} = this.props;
-        if (subEvents.items.length) {
-            for (const subEvent of subEvents.items) {
-                deleteEvent(subEvent.id, user)
-            }
-        }
-        return deleteEvent(this.props.match.params.eventId, user)
     }
 
     getWarningMarkup() {
@@ -241,7 +234,7 @@ const mapDispatchToProps = (dispatch) => ({
     routerPush: (url) => dispatch(push(url)),
     replaceData: (event) => dispatch(replaceDataAction(event)),
     confirm: (msg, style, actionButtonLabel, data) => dispatch(confirmAction(msg, style, actionButtonLabel, data)),
-    deleteEvent: (eventId, user) => dispatch(deleteEventAction(eventId, user)),
+    deleteEvent: (eventId, user, values) => dispatch(deleteEventAction(eventId, user, values)),
     cancelEvent: (eventId, user, values) => dispatch(cancelEventAction(eventId, user, values)),
     fetchSubEvents: (user, superEventId) => dispatch(fetchSubEventsAction(user, superEventId)),
 })


### PR DESCRIPTION
Resolve issue #380:
- automatically cancel all corresponding sub events when a super event is cancelled
- fix method for deleting and cancelling event to mass-delete/mass-cancel recursively, and reduce duplication
- fix wrong uses of warning message for cancelling event
- fix sub events not reloaded after one of them is cancelled (not sure if this happens when editting sub-events too)
- text translation for cancel warning message currently missing, gonna update soon