### PR TITLE
Fix/391 event delete redirect

### DIFF
--- a/src/views/Notification/index.js
+++ b/src/views/Notification/index.js
@@ -53,7 +53,7 @@ class Notifications extends React.Component {
                 open={(!!flashMsg)}
                 message={flashMsgSpan}
                 autoHideDuration={duration}
-                onRequestClose={closeFn}
+                onClose={closeFn}
                 action={[actionButton]}
             />
         )


### PR DESCRIPTION
Resolve issue #391 :
- now after deletion, redirect to events list (Manage events) page
- also fix notification/pop-up doesn't auto-hide correctly