### PR TITLE
Initial matomo implementation (WIP)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-helmet": "^2.2.0",
     "react-intl": "^2.4.0",
     "react-loader": "^2.0.0",
+    "react-piwik": "^1.6.0",
     "react-redux": "^4.0.5",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import {Route} from 'react-router'
 import PropTypes from 'prop-types'
+import ReactPiwik from 'react-piwik'
 
 import {Link, withRouter} from 'react-router-dom'
 import createHistory from 'history/createBrowserHistory' //'history/createHashHistory'
@@ -38,6 +39,14 @@ import IntlProviderWrapper from './components/IntlProviderWrapper'
 
 const history = createHistory()
 
+const matomo = new ReactPiwik({
+    url: 'https://analytics.hel.ninja',
+    siteId: 42,
+})
+
+// Track initial load
+ReactPiwik.push(['trackPageView'])
+
 const allReducers = combineReducers(Object.assign({}, reducers, {
     router: routerReducer,
 }))
@@ -64,7 +73,7 @@ const LayoutContainer = withRouter(connect()(App));
 ReactDOM.render(
     <Provider store={store}>
         <IntlProviderWrapper>
-            <ConnectedRouter history={history}>
+            <ConnectedRouter history={matomo.connectToHistory(history)}>
                 <LayoutContainer>
                     <Route exact path="/" component={EventListingPage}/>
                     <Route exact path="/event/:eventId" component={Event}/>

--- a/src/views/Search/index.js
+++ b/src/views/Search/index.js
@@ -4,6 +4,7 @@ import React from 'react'
 import {connect} from 'react-redux'
 import {FormattedMessage} from 'react-intl'
 import PropTypes from 'prop-types';
+import ReactPiwik from 'react-piwik';
 
 import FilterableEventTable from '../../components/FilterableEventTable'
 import EventGrid from '../../components/EventGrid'
@@ -25,16 +26,20 @@ class SearchPage extends React.Component {
         }
         else {
             this.props.fetchEvents(searchQuery, startDate, endDate)
-            this.setState({searchExecuted: true})
+            this.setState({searchExecuted: true, searchQuery: searchQuery})
         }
     }
 
     // <FilterableEventTable events={this.props.events} apiErrorMsg={''} />
 
     getResults() {
+
         if (this.state.searchExecuted && !this.props.events.length > 0) {
+            // Umm. Why?
+            ReactPiwik.push(['trackSiteSearch', this.state.searchQuery, false, this.props.events.length])
             return <div className="search-no-results"><FormattedMessage id="search-no-results"/></div>
         }
+        ReactPiwik.push(['trackSiteSearch', this.state.searchQuery, false, this.props.events.length])
         return <EventGrid events={this.props.events} apiErrorMsg={''}/>
     }
 


### PR DESCRIPTION
Initial implementation of matomo integration. Siteid is still hardcoded.
Before proceeding, I'd like to know what would be the best way to store the previous search query. Matomo can store search-events along with the amount of results returned. For LE-ui the results view does not remember the search query. I stuffed it into state for the search page. Is that the way it should be done?

Also getResults seems to be called two times per search, causing multiple search events in matomo. What gives?