### PR TITLE
Validate info url like other links

### DIFF
--- a/src/components/HelFormFields/NewOffer.js
+++ b/src/components/HelFormFields/NewOffer.js
@@ -109,8 +109,9 @@ class NewOffer extends React.Component {
                     ref="info_url" 
                     label="event-purchase-link" 
                     languages={languages} 
-                    onBlur={e => this.onBlur(e)} validations={[VALIDATION_RULES.IS_URL]} 
-                    validationErrors={this.props.validationErrors['info_url']} 
+                    onBlur={e => this.onBlur(e)}
+                    validations={[VALIDATION_RULES.IS_URL]}
+                    validationErrors={this.props.validationErrors['offer_info_url']}
                     index={this.props.offerKey}
                 />
 

--- a/src/validation/validator.js
+++ b/src/validation/validator.js
@@ -118,7 +118,7 @@ function runValidationWithSettings(values, languages, settings) {
 
 const validateEventObject = (validations, values, key) => {
     return validations.map(validation => {
-        if (key === 'offer_description' || key === 'price' || key === 'info_url') {
+        if (key === 'offer_description' || key === 'price') {
             return validateCollection(values, key, validation, 'offers')
         }
         return validationFn[validation](values, values[key]) ? null : validation

--- a/src/validation/validator.js
+++ b/src/validation/validator.js
@@ -94,8 +94,11 @@ function runValidationWithSettings(values, languages, settings) {
                 const error = isEmpty(subEventError) ? null : subEventError
                 errors[eventKey] = error
             })
+        // validate offers
+        } else if (key === 'price') {
+            errors = validateOffers(valuesWithLanguages)
         } else {
-            errors = validateEventObject(validations, valuesWithLanguages, key)
+            errors = validations.map(validation => validationFn[validation](valuesWithLanguages, valuesWithLanguages[key]) ? null : validation)
         }
 
         // Remove nulls
@@ -105,7 +108,12 @@ function runValidationWithSettings(values, languages, settings) {
             remove(errors, i => i === null)
         }
 
-        obj[key] = errors
+        // handle offers separately
+        if (key === 'price') {
+            obj = {...obj, ...errors}
+        } else {
+            obj[key] = errors
+        }
     })
     obj = pickBy(obj, (validationErrors, key) => {
         if (key === 'sub_events') {
@@ -116,23 +124,54 @@ function runValidationWithSettings(values, languages, settings) {
     return obj
 }
 
-const validateEventObject = (validations, values, key) => {
-    return validations.map(validation => {
-        if (key === 'offer_description' || key === 'price') {
-            return validateCollection(values, key, validation, 'offers')
-        }
-        return validationFn[validation](values, values[key]) ? null : validation
-    })
-}
+const validateOffers = values => {
+    const offers = values['offers']
 
-function validateCollection(values, key, validationRule, type) {
-    const targetKey = key === 'offer_description' ? 'description' : key
-    const valueByType = values[type]
-    let validations = []
-    for (const index in valueByType) {
-        if (!validationFn[validationRule](values, valueByType[index], targetKey)) {
-            validations.push({key: index, validation: validationRule})
-        }
+    if (!offers) {
+        return null
     }
-    return validations.length ? validations : null
+    // validation rules used for the offer fields
+    const offerValidationRules = {
+        price: VALIDATION_RULES.HAS_PRICE,
+        description: VALIDATION_RULES.LONG_STRING,
+        info_url: VALIDATION_RULES.IS_URL,
+    }
+    // prepends key names with prefix where applicable
+    const prependKeyName = key => {
+        const offerPrefix = 'offer_'
+
+        return key === 'info_url' || key === 'description'
+            ? `${offerPrefix}${key}`
+            : key
+    }
+
+    let errors = {}
+
+    // loop through all offers and get validation errors for each one
+    offers.forEach((offer, index) => {
+        const offerValidationErrors = Object.keys(offer)
+            .reduce((acc, key) => {
+                const validationRule = offerValidationRules[key]
+
+                if (validationRule) {
+                    // the data we need to pass to the validation function differs for description fields
+                    const valid = key === 'description'
+                        ? validationFn[validationRule](offer, offer[key], key)
+                        : validationFn[validationRule](values, offer, key)
+
+                    if (!valid) {
+                        acc[prependKeyName(key)] = [{key: `${index}`, validation: validationRule}]
+                    }
+                }
+                return acc
+            }, {})
+
+        // add validation errors to the errors object
+        each(offerValidationErrors, (value, key) => {
+            Object.getOwnPropertyNames(errors).includes(key)
+                ? errors[key][0].push(...value)
+                : errors[key] = [value]
+        })
+    })
+    return errors
 }


### PR DESCRIPTION
Fixes #408 

- Offers are now validated separately from others to fix issues with conflicting field naming
- The offer description field is now validated using the longString rule. It wasn't validated / didn't work before.