### PR TITLE
#435 - Fix validation with multiple languages

### DIFF
--- a/src/actions/editor.js
+++ b/src/actions/editor.js
@@ -215,7 +215,7 @@ const prepareFormValues = (formValues, contentLanguages, user, updateExisting, p
     }
 
     // Format descriptions to HTML
-    const descriptionTexts = multiLanguageValues.description || formValues.description
+    const descriptionTexts = cleanedFormValues.description
     for (const lang in descriptionTexts) {
         if (descriptionTexts[lang]) {
             const desc = descriptionTexts[lang].replace(/\n\n/g, '</p><p>').replace(/\n/g, '<br/>').replace(/&/g, '&amp;')

--- a/src/actions/editor.js
+++ b/src/actions/editor.js
@@ -196,7 +196,7 @@ const prepareFormValues = (formValues, contentLanguages, user, updateExisting, p
                 Object.keys(offer)
                     // filter out the is_free key
                     .filter(key => key !== 'is_free')
-                    .forEach(key => multiLanguageValues[field][index][key] = nullifyField(offer[key]))
+                    .forEach(key => multiLanguageValues[field][index][key] = !isNil(offer[key]) ? nullifyField(offer[key]) : null)
             })
             continue
         }

--- a/src/actions/editor.js
+++ b/src/actions/editor.js
@@ -1,6 +1,6 @@
 import fetch from 'isomorphic-fetch'
 import moment from 'moment';
-import {includes, keys, pickBy} from 'lodash';
+import {includes, keys, pickBy, set, isUndefined} from 'lodash';
 
 import constants from '../constants'
 import {
@@ -163,7 +163,7 @@ export function validateFor(publicationStatus) {
  * @return {[type]}                         [description]
  */
 
-const multiLanguageFields = ['name', 'description', 'short_description', 'provider', 'location_extra_info']
+const multiLanguageFields = ['name', 'description', 'short_description', 'provider', 'location_extra_info', 'info_url', 'offers']
 
 const prepareFormValues = (formValues, contentLanguages, user, updateExisting, publicationStatus, dispatch) => {
     // exclude all existing sub events from editing form
@@ -175,36 +175,51 @@ const prepareFormValues = (formValues, contentLanguages, user, updateExisting, p
     if(formValues.sub_events) {
         recurring = keys(formValues.sub_events).length > 0
     }
+
+    // nullify language fields that are not included in contentLanguages as they should not be posted
+    const nullifyField = value => Object.keys(value)
+        .reduce((acc, key) => set(acc, key, contentLanguages.includes(key) ? value[key] : null), {})
+
+    const multiLanguageValues = {}
+
+    for (const field of multiLanguageFields) {
+        const fieldValue = formValues[field];
+        // some multi-language fields might not have a value
+        if (isUndefined(fieldValue)) {
+            continue
+        }
+        if (field === 'offers') {
+            multiLanguageValues[field] = []
+            // nullify multi-language fields for every offer
+            fieldValue.forEach((offer, index) => {
+                multiLanguageValues[field].push(offer)
+                Object.keys(offer)
+                    // filter out the is_free key
+                    .filter(key => key !== 'is_free')
+                    .forEach(key => multiLanguageValues[field][index][key] = nullifyField(offer[key]))
+            })
+            continue
+        }
+        multiLanguageValues[field] = nullifyField(fieldValue)
+    }
+
+    // merge the "cleaned" multi-language value fields with the form values
+    const cleanedFormValues = {...formValues, ...multiLanguageValues}
+
     // Run validations
-    let validationErrors = doValidations(formValues, contentLanguages, publicationStatus)
+    const validationErrors = doValidations(cleanedFormValues, contentLanguages, publicationStatus)
 
     // There are validation errors, don't continue sending
     if (keys(validationErrors).length > 0) {
         return dispatch(setValidationErrors(validationErrors))
     }
 
-    const multiLanguageValues = {}
-    // Language fields not included in contentLanguages should not be posted, they aren't validated anyway
-    for (var field of multiLanguageFields) {
-        for (const lang in formValues[field]) {
-            if (!(field in multiLanguageValues)) {
-                multiLanguageValues[field] = {}
-            }
-            if (contentLanguages.includes(lang)) {
-                multiLanguageValues[field][lang] = formValues[field][lang]
-            } else {
-                // Null is needed here to overwrite any existing strings in the backend
-                multiLanguageValues[field][lang] = null
-            }
-        }
-    }
-
     // Format descriptions to HTML
-    const descriptionTexts = formValues.description
-    for (const lang in formValues.description) {
-        if (formValues.description[lang]) {
-            const desc = formValues.description[lang].replace(/\n\n/g, '</p><p>').replace(/\n/g, '<br/>').replace(/&/g, '&amp;')
-            if (desc.indexOf('<p>') === 0 && desc.substr(desc.length - 4) === '</p>') {
+    const descriptionTexts = multiLanguageValues.description || formValues.description
+    for (const lang in descriptionTexts) {
+        if (descriptionTexts[lang]) {
+            const desc = descriptionTexts[lang].replace(/\n\n/g, '</p><p>').replace(/\n/g, '<br/>').replace(/&/g, '&amp;')
+            if (desc.indexOf('<p>') === 0 && desc.substring(desc.length - 4) === '</p>') {
                 descriptionTexts[lang] = desc
             } else {
                 descriptionTexts[lang] = `<p>${desc}</p>`
@@ -223,8 +238,8 @@ const prepareFormValues = (formValues, contentLanguages, user, updateExisting, p
         }
     }
 
-    let data = Object.assign({}, formValues, multiLanguageValues, {publication_status: publicationStatus, description: descriptionTexts})
-    
+    let data = {...cleanedFormValues, publication_status: publicationStatus, description: descriptionTexts}
+
     // specific processing for event with multiple dates
     if (recurring) {
         data = combineSubEventsFromEditor(data, updateExisting)

--- a/src/actions/editor.js
+++ b/src/actions/editor.js
@@ -1,6 +1,6 @@
 import fetch from 'isomorphic-fetch'
 import moment from 'moment';
-import {includes, keys, pickBy, set, isUndefined} from 'lodash';
+import {includes, keys, pickBy, set, isNil} from 'lodash';
 
 import constants from '../constants'
 import {
@@ -185,7 +185,7 @@ const prepareFormValues = (formValues, contentLanguages, user, updateExisting, p
     for (const field of multiLanguageFields) {
         const fieldValue = formValues[field];
         // some multi-language fields might not have a value
-        if (isUndefined(fieldValue)) {
+        if (isNil(fieldValue)) {
             continue
         }
         if (field === 'offers') {

--- a/src/components/HelFormFields/HelLanguageSelect.js
+++ b/src/components/HelFormFields/HelLanguageSelect.js
@@ -9,8 +9,6 @@ import {Checkbox} from 'react-bootstrap'
 import {connect} from 'react-redux'
 import {setLanguages as setLanguageAction} from 'src/actions/editor.js'
 
-import {map} from 'lodash'
-
 class HelLanguageSelect extends React.Component {
 
     constructor(props) {
@@ -19,27 +17,25 @@ class HelLanguageSelect extends React.Component {
         this.onChange = this.onChange.bind(this)
     }
 
-    onChange(e) {
+    onChange() {
         const {options} = this.props
+        const checkedOptions = options
+            .filter((option, index) => this[`checkRef${index}`].checked)
+            .map(checkedOption => checkedOption.value)
 
-        let checked = options.reduce((ac, op, index) => {
-            if(this[`checkRef${index}`].checked) {
-                ac.push(this[`checkRef${index}`]) 
-            }
-            return ac
-        }, [])
+        this.props.setLanguages(checkedOptions)
 
-        let checkedNames = map(checked, (checkbox) => (checkbox.name) )
-        this.props.setLanguages(checkedNames)
-
-        if(typeof this.props.onChange === 'function') {
-            this.props.onChange(checkedNames)
+        if (typeof this.props.onChange === 'function') {
+            this.props.onChange(checkedOptions)
         }
     }
 
     render() {
         let checkboxes = this.props.options.map((item, index) => {
-            let checked = this.props.checked && (this.props.checked.indexOf(item.value) > -1)
+            const checkedOptions = this.props.checked;
+            let checked = checkedOptions && checkedOptions.includes(item.value)
+            let disabled = checked && checkedOptions && checkedOptions.length === 1
+
             return (<Checkbox
                 style={{width: 'auto'}}
                 className="hel-checkbox inline"
@@ -47,6 +43,7 @@ class HelLanguageSelect extends React.Component {
                 key={index}
                 name={item.value}
                 checked={checked}
+                disabled={disabled}
                 onChange={this.onChange}
             >
                 <FormattedMessage id={item.label} />

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,4 +1,4 @@
-import {isArray} from 'lodash';
+import {isArray, isNull, some} from 'lodash';
 
 import CONSTANTS from '../constants'
 
@@ -28,21 +28,11 @@ export const getCharacterLimitByRule = (ruleName) => {
  * @param  {int} limit
  * @return {boolean} validation status
  */
-
-export function textLimitValidator(value, limit) {
-    if(typeof value === 'object') {
-        let hasOneOverLimit = false
-        _.each(value, item => {
-            if(item.length > limit) {
-                hasOneOverLimit = true
-            }
-        })
-        return !hasOneOverLimit
-
-    } else if(typeof value === 'string') {
-        if(value.length > limit) {
-            return false
-        }
+export const textLimitValidator = (value, limit) => {
+    if (typeof value === 'object') {
+        return !some(value, item => !isNull(item) && item.length > limit)
+    } else if (typeof value === 'string') {
+        return value.length <= limit
     }
     return true
 }

--- a/src/validation/validationRules.js
+++ b/src/validation/validationRules.js
@@ -1,6 +1,6 @@
 
 import moment from 'moment'
-import {includes, every} from 'lodash';
+import {includes, every, isNull} from 'lodash';
 import CONSTANT from '../constants'
 import {textLimitValidator} from '../utils/helpers'
 /**
@@ -16,10 +16,10 @@ let isEmpty = function isEmpty(value) {
     return value === '';
 }
 
-const _containsAllLanguages = function _containsAllLanguages(value, languages) {
+const _containsAllLanguages = (value, languages) => {
     let requiredLanguages = new Set(languages)
     _.forOwn(value, (item, key) => {
-        if (item.length && item.length > 0) {
+        if (isNull(item) || item.length && item.length > 0) {
             requiredLanguages.delete(key)
         }
     })
@@ -188,14 +188,14 @@ var validations = {
         }
         return this.requiredString(values, value);
     },
-    requiredMulti: function requiredMulti(values, value) {
+    requiredMulti(values, value) {
         if(typeof value !== 'object' || !value) {
             return false
         }
         if(_.keys(value).length === 0) {
             return false
         }
-        return every(value, item => item.trim() && item.trim().length > 0)
+        return every(value, item => isNull(item) || item.trim() && item.trim().length > 0)
     },
     requiredAtId: function requiredAtId(values, value) {
         if(typeof value !== 'object' || !value) {


### PR DESCRIPTION
This PR fixes #435 

- Fix issue where the values of deselected languages weren’t nullified
- Multiple language fields for offers are now nullified, they weren’t before
- Validation is now run after the multiple language field values have been nullified. This fixes the issue where invalid values for deselected languages triggered validation warnings
- Unselecting all languages is no longer possible