### PR TITLE
244: Allow searching for events in a time range without search text

### DIFF
--- a/src/views/Search/index.js
+++ b/src/views/Search/index.js
@@ -3,15 +3,13 @@ import './index.scss'
 import React from 'react'
 import {connect} from 'react-redux'
 import {FormattedMessage} from 'react-intl'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 
-import FilterableEventTable from '../../components/FilterableEventTable'
 import EventGrid from '../../components/EventGrid'
 import SearchBar from '../../components/SearchBar'
 import Loader from 'react-loader'
 
 import {fetchEvents as fetchEventsAction} from '../../actions/events'
-
 
 class SearchPage extends React.Component {
     constructor(props) {
@@ -20,16 +18,13 @@ class SearchPage extends React.Component {
     }
 
     searchEvents(searchQuery, startDate, endDate) {
-        if (!searchQuery) {
+        if (!searchQuery && (!startDate || !endDate)) {
             return
         }
-        else {
-            this.props.fetchEvents(searchQuery, startDate, endDate)
-            this.setState({searchExecuted: true})
-        }
-    }
 
-    // <FilterableEventTable events={this.props.events} apiErrorMsg={''} />
+        this.props.fetchEvents(searchQuery, startDate, endDate)
+        this.setState({searchExecuted: true})
+    }
 
     getResults() {
         if (this.state.searchExecuted && !this.props.events.length > 0) {
@@ -43,7 +38,7 @@ class SearchPage extends React.Component {
             <div className="container">
                 <h1><FormattedMessage id={`search-${appSettings.ui_mode}`}/></h1>
                 <p><FormattedMessage id="search-events-description"/></p>
-                <SearchBar onFormSubmit={ (query, start, end) => this.searchEvents(query, start, end) }/>
+                <SearchBar onFormSubmit={(query, start, end) => this.searchEvents(query, start, end)}/>
                 <Loader loaded={!this.props.isFetching} scale={3}>
                     {this.getResults()}
                 </Loader>
@@ -71,4 +66,4 @@ const mapDispatchToProps = (dispatch) => {
         fetchEvents: (searchQuery, startDate, endDate) => dispatch(fetchEventsAction(searchQuery, startDate, endDate)),
     }
 }
-export default connect(mapStateToProps, mapDispatchToProps)(SearchPage);
+export default connect(mapStateToProps, mapDispatchToProps)(SearchPage)


### PR DESCRIPTION
https://github.com/City-of-Helsinki/linkedevents-ui/issues/244
I also needed to change EventGrid so that it doesn't crash when event doesn't have fi, en, or sv values for name and subject fields. This is possible when events are searched without search text.
