### PR TITLE
Fix/316 add validation to image upload name field

### DIFF
--- a/src/actions/userImages.js
+++ b/src/actions/userImages.js
@@ -104,7 +104,7 @@ export function postImage(formData, user, imageId = null) {
             
             dispatch(setFlashMsg(imageId ? 'image-update-success' : 'image-creation-success', 'success', request))
         } catch (error) {
-            dispatch(setFlashMsg('image-creation-error', 'error', error));
+            dispatch(setFlashMsg('image-creation-error', 'error'));
     
             dispatch(imageUploadFailed(error));
             

--- a/src/actions/userImages.js
+++ b/src/actions/userImages.js
@@ -94,11 +94,17 @@ export function imageUploadComplete(json) {
 export function postImage(formData, user, imageId = null) {
     return async (dispatch) => {
         try {
+            let request;
+            
             // Use PUT when updating the existing image metadata, use POST when adding a new image.
-            const request = (imageId) ? await client.put(`image/${imageId}`, formData) : await client.post(`image/`, formData);
-
-            // Append updated image data to the form
-            dispatch(setData({'image': request}));
+            if (imageId) {
+                request = await client.put(`image/${imageId}`, formData);
+            } else {
+                request = await client.post(`image/`, formData);
+                
+                // Append uploaded image data to the form
+                dispatch(setData({'image': request.data}));
+            }
             
             dispatch(imageUploadComplete(request));
             

--- a/src/components/HelFormFields/HelTextField.js
+++ b/src/components/HelFormFields/HelTextField.js
@@ -16,6 +16,7 @@ import CONSTANTS from '../../constants'
 class HelTextField extends React.Component {
     constructor(props) {
         super(props)
+        
         this.state = {
             error: null,
             value: this.props.defaultValue || '',
@@ -44,7 +45,7 @@ class HelTextField extends React.Component {
             }
             else if(isMediumString) {
                 limit = CONSTANTS.CHARACTER_LIMIT.MEDIUM_STRING
-            } 
+            }
             else if(isLongString) {
                 limit = CONSTANTS.CHARACTER_LIMIT.LONG_STRING
             }
@@ -55,6 +56,7 @@ class HelTextField extends React.Component {
                 return this.context.intl.formatMessage({id: 'validation-stringLengthCounter'}, {counter: diff})
             }
         }
+        
         return this.state.error
     }
 
@@ -117,8 +119,8 @@ class HelTextField extends React.Component {
     }
 
     componentDidMount() {
-        this.setValidationErrorsToState()
-        this.recalculateHeight()
+        this.setValidationErrorsToState();
+        this.recalculateHeight();
     }
 
     recalculateHeight() {
@@ -157,12 +159,12 @@ class HelTextField extends React.Component {
     componentDidUpdate() {
         this.recalculateHeight()
     }
-
+    
     setValidationErrorsToState() {
         const {VALIDATION_RULES, CHARACTER_LIMIT} = CONSTANTS
 
         let errors = this.getValidationErrors()
-
+        
         if(errors.length > 0) {
             let limit
 
@@ -179,7 +181,7 @@ class HelTextField extends React.Component {
             }
             
             return limit ? this.setState({error: this.context.intl.formatMessage({id: `validation-stringLimitReached`}, {limit})}) :
-                this.setState({error: this.context.intl.formatMessage({id: `validation-${errors[0].rule}`})}) 
+                this.setState({error: this.context.intl.formatMessage({id: `validation-${errors[0].rule}`})})
         }
         else {
             this.setState({error: null})
@@ -189,10 +191,6 @@ class HelTextField extends React.Component {
     noValidationErrors() {
         let errors = this.getValidationErrors()
         return (errors.length === 0)
-    }
-
-    validationState() {
-        return this.state.error ? 'warning' : 'success'
     }
 
     render () {
@@ -216,7 +214,7 @@ class HelTextField extends React.Component {
         } else {
             type = this.props.multiLine ? 'textarea' : 'input'
         }
-
+        
         return (
             <span style={{position: 'relative'}}>
                 <div className={groupClassName}>
@@ -231,6 +229,7 @@ class HelTextField extends React.Component {
                         name={this.props.name}
                         rows="1"
                         disabled={this.props.disabled}
+                        maxLength={(this.props.maxLength) ? this.props.maxLength : null}
                     />
                     <HelpBlock>{this.helpText()}</HelpBlock>
                 </div>
@@ -264,6 +263,7 @@ HelTextField.propTypes = {
     index: PropTypes.string,
     disabled: PropTypes.bool,
     type: PropTypes.string,
+    maxLength: PropTypes.number,
 }
 
 export default HelTextField

--- a/src/components/ImageEdit/index.js
+++ b/src/components/ImageEdit/index.js
@@ -10,7 +10,7 @@ import {connect} from 'react-redux'
 import FormFields from '../FormFields'
 import HelTextField from '../HelFormFields/HelTextField'
 
-import CONSTANTS from '../../constants' 
+import CONSTANTS from '../../constants'
 import {postImage as postImageAction} from 'src/actions/userImages'
 
 class ImageEdit extends React.Component {
@@ -22,6 +22,8 @@ class ImageEdit extends React.Component {
             name: this.props.defaultName || '',
             photographerName: this.props.defaultPhotographerName || '',
             license: this.props.license || 'cc_by',
+            nameMinLength: 6,
+            nameMaxLength: CONSTANTS.CHARACTER_LIMIT.SHORT_STRING,
         }
     }
 
@@ -70,12 +72,16 @@ class ImageEdit extends React.Component {
                         <div className="col-sm-8 edit-form">
                             <div className="hel-text-field">
                                 <label className="hel-label">
-                                    <FormattedMessage id={'image-caption-limit'} values={{limit:CONSTANTS.CHARACTER_LIMIT.SHORT_STRING}}/>
+                                    <FormattedMessage id={'image-caption-limit-for-min-and-max'} values={{
+                                        minLength: this.state.nameMinLength,
+                                        maxLength: this.state.nameMaxLength}}/>
+                                    
                                 </label>
                                 <HelTextField
                                     onChange={(e) => this.handleTextChange(e, 'name')}
                                     defaultValue={this.state.name}
                                     validations={[CONSTANTS.VALIDATION_RULES.SHORT_STRING]}
+                                    maxLength={this.state.nameMaxLength}
                                 />
                             </div>
                             <div className="hel-text-field">
@@ -100,7 +106,7 @@ class ImageEdit extends React.Component {
                             </div>
                         </div>
                         <img className="col-sm-4 edit-form form-image" src={this.props.thumbnailUrl} />
-                        <button type="submit" className="col-sm-12 btn btn-save-image-data">Tallenna tiedot</button>
+                        <button type="submit" className="col-sm-12 btn btn-save-image-data" disabled={(this.state.name.length >= 6) ? false : true}>Tallenna tiedot</button>
 
                     </form>
                 </Modal.Body>

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -253,5 +253,7 @@
     "search-courses": "Etsi kursseja",
     "more-info": "Lisätietoja",
     "courses-management": "Kurssien hallinta",
-    "edit-image": "Muokkaa kuvaa"
+    "edit-image": "Muokkaa kuvaa",
+    "The name must be defined.": "Tiedostolla tulee olla nimi",
+    "image-caption-limit-for-min-and-max": "Kuvaus eli kuvan alt-teksti (pituus vähintään {minLength} ja korkeintaan {maxLength} merkkiä)"
 }


### PR DESCRIPTION
This fix adds a simple validation for minimum & maximum length of a text input & makes sure that the newly uploaded image is added to the form.