### PR TITLE
Show Moderation page based on has_regular_user field

### DIFF
--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -80,9 +80,9 @@ export const retrieveUserFromSession = () => async (dispatch) => {
             // store data of all the organizations where the user is a regular user
             mergedUser.regularOrganizationData = regularOrganizations
                 .reduce((acc, organization) => set(acc, `${organization.data.id}`, organization.data), {})
-            // get the affiliated organizations
-            mergedUser.affiliatedOrganizations = adminOrganizations
-                .filter(organization => get(organization, ['data', 'is_affiliated'], false))
+            // get organizations with regular users
+            mergedUser.organizationsWithRegularUsers = adminOrganizations
+                .filter(organization => get(organization, ['data', 'has_regular_users'], false))
                 .map(organization => organization.data.id)
 
             saveUserToLocalStorage(mergedUser)

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -27,7 +27,7 @@ import {Link} from 'react-router-dom'
 import constants from '../../constants'
 
 import cityOfHelsinkiLogo from '../../assets/images/helsinki-logo.svg'
-import {hasAffiliatedOrganizations} from '../../utils/user'
+import {hasOrganizationWithRegularUsers} from '../../utils/user'
 import {get} from 'lodash'
 
 const {USER_TYPE, APPLICATION_SUPPORT_TRANSLATION} = constants
@@ -42,7 +42,7 @@ class HeaderBar extends React.Component {
         const {user} = this.props
 
         if (user) {
-            const showModerationLink = get(user, 'userType') === USER_TYPE.ADMIN && hasAffiliatedOrganizations(user)
+            const showModerationLink = get(user, 'userType') === USER_TYPE.ADMIN && hasOrganizationWithRegularUsers(user)
             this.setState({showModerationLink})
         }
     }
@@ -52,7 +52,7 @@ class HeaderBar extends React.Component {
         const oldUser = prevProps.user
 
         if (oldUser !== user) {
-            const showModerationLink = get(user, 'userType') === USER_TYPE.ADMIN && hasAffiliatedOrganizations(user)
+            const showModerationLink = get(user, 'userType') === USER_TYPE.ADMIN && hasOrganizationWithRegularUsers(user)
             this.setState({showModerationLink})
         }
     }

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -33,11 +33,11 @@ export const getRegularOrganizations = user =>
         .map(getOrganization)
 
 /**
- * Returns whether the given user has any affiliated organizations
+ * Returns whether the given user is an admin in any organization that has regular users
  * @param user  User data
  */
-export const hasAffiliatedOrganizations = user =>
-    get(user, 'affiliatedOrganizations', []).length > 0
+export const hasOrganizationWithRegularUsers = user =>
+    get(user, 'organizationsWithRegularUsers', []).length > 0
 
 
 /**

--- a/src/views/Editor/index.js
+++ b/src/views/Editor/index.js
@@ -21,7 +21,10 @@ import FormFields from '../../components/FormFields'
 import {EventQueryParams, fetchEvent} from '../../utils/events'
 import {push} from 'react-router-redux'
 import moment from 'moment'
-import {getOrganizationMembershipIds, hasAffiliatedOrganizations} from '../../utils/user'
+import {
+    getOrganizationMembershipIds,
+    hasOrganizationWithRegularUsers,
+} from '../../utils/user'
 import EventActionButton from '../../components/EventActionButton/EventActionButton'
 import {scrollToTop} from '../../utils/helpers'
 import {doValidations} from '../../validation/validator'
@@ -220,7 +223,7 @@ export class EditorPage extends React.Component {
 
         // navigate to moderation if an admin deleted a draft event, otherwise navigate to event listing
         if (action === 'delete') {
-            if (isDraft && hasAffiliatedOrganizations(user)) {
+            if (isDraft && hasOrganizationWithRegularUsers(user)) {
                 this.navigateToModeration();
             } else {
                 routerPush('/')
@@ -308,13 +311,13 @@ export class EditorPage extends React.Component {
                         : <div className='buttons-group container'>
                             {editMode === 'update' && this.getActionButton('cancel')}
                             {editMode === 'update' && this.getActionButton('delete')}
-                            {isDraft && hasAffiliatedOrganizations(user) &&
+                            {isDraft && hasOrganizationWithRegularUsers(user) &&
                                 this.getActionButton('return', this.navigateToModeration, false)
                             }
                             {
                                 // button that saves changes to a draft without publishing
                                 // only shown to moderators
-                                isDraft && hasAffiliatedOrganizations(user) &&
+                                isDraft && hasOrganizationWithRegularUsers(user) &&
                                 this.getActionButton(
                                     'update-draft',
                                     this.saveChangesToDraft,

--- a/src/views/Event/index.js
+++ b/src/views/Event/index.js
@@ -18,7 +18,7 @@ import {getBadge, scrollToTop} from '../../utils/helpers'
 
 import './index.scss'
 import EventActionButton from '../../components/EventActionButton/EventActionButton'
-import {hasAffiliatedOrganizations} from '../../utils/user'
+import {hasOrganizationWithRegularUsers} from '../../utils/user'
 
 const {
     USER_TYPE,
@@ -201,7 +201,7 @@ class EventPage extends React.Component {
 
         // navigate to moderation if an admin deleted a draft event, otherwise navigate to event listing
         if (action === 'delete') {
-            if (isDraft && hasAffiliatedOrganizations(user)) {
+            if (isDraft && hasOrganizationWithRegularUsers(user)) {
                 routerPush('/moderation')
             } else {
                 routerPush('/')

--- a/src/views/Moderation/Moderation.js
+++ b/src/views/Moderation/Moderation.js
@@ -18,7 +18,7 @@ import {
 import {getSelectedRows, getSortColumnName, getSortDirection} from '../../utils/table'
 import showConfirmationModal from '../../utils/confirm'
 import {confirmAction, setFlashMsg as setFlashMsgAction} from '../../actions/app'
-import {hasAffiliatedOrganizations} from '../../utils/user'
+import {hasOrganizationWithRegularUsers} from '../../utils/user'
 import {push} from 'react-router-redux'
 
 const {TABLE_DATA_SHAPE, PUBLICATION_STATUS} = constants
@@ -53,7 +53,7 @@ export class Moderation extends React.Component {
     componentDidMount() {
         const {user} = this.props
 
-        if (!isNull(user) && hasAffiliatedOrganizations(user)) {
+        if (!isNull(user) && hasOrganizationWithRegularUsers(user)) {
             this.fetchTableData(['draft', 'published'])
         }
     }
@@ -67,7 +67,7 @@ export class Moderation extends React.Component {
             routerPush('/')
         }
         // fetch data if user logged in
-        if (isNull(oldUser) && user && hasAffiliatedOrganizations(user)) {
+        if (isNull(oldUser) && user && hasOrganizationWithRegularUsers(user)) {
             this.fetchTableData(['draft', 'published'])
         }
     }
@@ -297,10 +297,11 @@ export class Moderation extends React.Component {
 
     /**
      * Return the default query params to use when fetching event data
+     * @param table     The table to get the parameters for
      * @returns {EventQueryParams}
      */
     getDefaultEventQueryParams = (table) => {
-        const {user: {affiliatedOrganizations}} = this.props
+        const {user: {organizationsWithRegularUsers}} = this.props
         const {pageSize, sortBy, sortDirection} = this.state[`${table}Data`]
 
         const queryParams = new EventQueryParams()
@@ -308,7 +309,7 @@ export class Moderation extends React.Component {
         queryParams.admin_user = table === 'draft' ? true : null
         queryParams.super_event = 'none'
         queryParams.publication_status = this.getPublicationStatus(table)
-        queryParams.setPublisher(affiliatedOrganizations)
+        queryParams.setPublisher(organizationsWithRegularUsers)
         queryParams.page_size = pageSize
         queryParams.setSort(sortBy, sortDirection)
 


### PR DESCRIPTION
Show moderation page / fetch moderation data based on organizations that have regular users rather than affiliated organizations

**NOTE:** The changes are done with the assumption that the user is an admin in the organizations, but that they don't need to be affiliated with the organization that the user belongs to.