### PR TITLE
Fix event title field text disappearing when editing the image caption field

### DIFF
--- a/src/actions/userImages.js
+++ b/src/actions/userImages.js
@@ -104,10 +104,10 @@ export function postImage(formData, user, imageId = null) {
                 request = await client.put(`image/${imageId}`, formData);
             } else {
                 request = await client.post(`image/`, formData);
-                
-                // Append uploaded image data to the form
-                dispatch(setData({'image': request.data}));
             }
+
+            // Append uploaded image data to the form
+            dispatch(setData({'image': request.data}));
             
             dispatch(imageUploadComplete(request));
             

--- a/src/components/HelFormFields/HelTextField.js
+++ b/src/components/HelFormFields/HelTextField.js
@@ -238,7 +238,6 @@ HelTextField.propTypes = {
     index: PropTypes.string,
     disabled: PropTypes.bool,
     type: PropTypes.string,
-    maxLength: PropTypes.number,
 }
 
 export default HelTextField

--- a/src/components/HelFormFields/HelTextField.js
+++ b/src/components/HelFormFields/HelTextField.js
@@ -94,15 +94,18 @@ class HelTextField extends React.Component {
     }
 
     handleBlur = (event) => {
-        const {name, forceApplyToStore, setDirtyState, onBlur} = this.props
+        const {name, forceApplyToStore, setDirtyState, onBlur, updateStore} = this.props
         const value = event.target.value
 
-        // Apply changes to store if no validation errors, or the prop 'forceApplyToStore' is defined
-        if (
-            name
-            && this.getValidationErrors().length === 0
-            && !name.includes('time') || name
-            && forceApplyToStore
+        // Apply changes to store if updateStore is true and if no validation errors or the prop 'forceApplyToStore' is
+        // defined
+        // TODO: updating the store inside a low level component like this doesn't seem like a good idea. Refactor the
+        // store logic out to a higher level so the user of the component can choose whether to use the store or not.
+        if (updateStore
+            && (
+                (name && this.getValidationErrors().length === 0 && !name.includes('time'))
+                || (name && forceApplyToStore)
+            )
         ) {
             this.context.dispatch(setData({[name]: value}))
 
@@ -213,6 +216,10 @@ class HelTextField extends React.Component {
     }
 }
 
+HelTextField.defaultProps = {
+    updateStore: true,
+}
+
 HelTextField.propTypes = {
     name: PropTypes.string,
     placeholder: PropTypes.string,
@@ -238,6 +245,7 @@ HelTextField.propTypes = {
     index: PropTypes.string,
     disabled: PropTypes.bool,
     type: PropTypes.string,
+    updateStore: PropTypes.bool,
 }
 
 export default HelTextField

--- a/src/components/ImageEdit/index.js
+++ b/src/components/ImageEdit/index.js
@@ -176,10 +176,10 @@ const ImageEdit = (props) => {
                         />
                         <TextField
                             fullWidth
-                            name="photographerName"
-                            label={<FormattedMessage id={'photographer'}/>}
-                            value={photographerName}
                             onChange={handleStateChange}
+                            name="photographerName"
+                            value={photographerName}
+                            label={<FormattedMessage id={'photographer'}/>}
                         />
                         <Typography
                             style={{marginTop: HelMaterialTheme.spacing(2)}}

--- a/src/components/ImageEdit/index.js
+++ b/src/components/ImageEdit/index.js
@@ -58,7 +58,7 @@ const handleImagePost = ({
     postImage,
     user,
     id,
-    close,
+    onSave,
 }) => {
     const data = new FormData()
 
@@ -74,7 +74,7 @@ const handleImagePost = ({
     data.append('license', license)
 
     postImage(data, user, updateExisting ? id : null)
-    close()
+    onSave()
 }
 
 /**
@@ -249,6 +249,7 @@ ImageEdit.propTypes = {
     user: PropTypes.object,
     id: PropTypes.number,
     close: PropTypes.func,
+    onSave: PropTypes.func,
 }
 
 const mapStateToProps = (state) => ({

--- a/src/components/ImageEdit/index.js
+++ b/src/components/ImageEdit/index.js
@@ -18,12 +18,11 @@ import {
 } from '@material-ui/core'
 import {Close} from '@material-ui/icons'
 import {connect} from 'react-redux'
-import HelTextField from '../HelFormFields/HelTextField'
 import {postImage as postImageAction} from 'src/actions/userImages'
 import {HelMaterialTheme} from '../../themes/material-ui'
 import constants from '../../constants'
 
-const {CHARACTER_LIMIT, VALIDATION_RULES} = constants
+const {CHARACTER_LIMIT} = constants
 
 const InlineRadioGroup = withStyles({
     root: {
@@ -145,13 +144,13 @@ const ImageEdit = (props) => {
             <DialogContent>
                 <form onSubmit={() => handleImagePost(state, props)} className="row">
                     <div className="col-sm-8 image-edit-dialog--form">
-                        <HelTextField
+                        <TextField
+                            fullWidth
                             multiLine
                             onChange={handleStateChange}
                             name="altText"
                             required={true}
-                            defaultValue={altText}
-                            validations={[VALIDATION_RULES.MEDIUM_STRING]}
+                            value={altText}
                             label={
                                 <FormattedMessage
                                     id={'alt-text'}
@@ -161,12 +160,12 @@ const ImageEdit = (props) => {
                                 />
                             }
                         />
-                        <HelTextField
+                        <TextField
+                            fullWidth
                             multiLine
                             onChange={handleStateChange}
                             name="name"
-                            defaultValue={name}
-                            validations={[VALIDATION_RULES.SHORT_STRING]}
+                            value={name}
                             label={
                                 <FormattedMessage
                                     id={'image-caption-limit-for-min-and-max'}

--- a/src/components/ImageEdit/index.js
+++ b/src/components/ImageEdit/index.js
@@ -152,7 +152,6 @@ const ImageEdit = (props) => {
                             required={true}
                             defaultValue={altText}
                             validations={[VALIDATION_RULES.MEDIUM_STRING]}
-                            maxLength={altTextMaxLength}
                             label={
                                 <FormattedMessage
                                     id={'alt-text'}
@@ -168,7 +167,6 @@ const ImageEdit = (props) => {
                             name="name"
                             defaultValue={name}
                             validations={[VALIDATION_RULES.SHORT_STRING]}
-                            maxLength={nameMaxLength}
                             label={
                                 <FormattedMessage
                                     id={'image-caption-limit-for-min-and-max'}

--- a/src/components/ImageEdit/index.js
+++ b/src/components/ImageEdit/index.js
@@ -18,11 +18,12 @@ import {
 } from '@material-ui/core'
 import {Close} from '@material-ui/icons'
 import {connect} from 'react-redux'
+import HelTextField from '../HelFormFields/HelTextField'
 import {postImage as postImageAction} from 'src/actions/userImages'
 import {HelMaterialTheme} from '../../themes/material-ui'
 import constants from '../../constants'
 
-const {CHARACTER_LIMIT} = constants
+const {CHARACTER_LIMIT, VALIDATION_RULES} = constants
 
 const InlineRadioGroup = withStyles({
     root: {
@@ -144,13 +145,14 @@ const ImageEdit = (props) => {
             <DialogContent>
                 <form onSubmit={() => handleImagePost(state, props)} className="row">
                     <div className="col-sm-8 image-edit-dialog--form">
-                        <TextField
-                            fullWidth
+                        <HelTextField
                             multiLine
                             onChange={handleStateChange}
                             name="altText"
                             required={true}
-                            value={altText}
+                            defaultValue={altText}
+                            validations={[VALIDATION_RULES.MEDIUM_STRING]}
+                            updateStore={false}
                             label={
                                 <FormattedMessage
                                     id={'alt-text'}
@@ -160,12 +162,13 @@ const ImageEdit = (props) => {
                                 />
                             }
                         />
-                        <TextField
-                            fullWidth
+                        <HelTextField
                             multiLine
                             onChange={handleStateChange}
                             name="name"
-                            value={name}
+                            defaultValue={name}
+                            validations={[VALIDATION_RULES.SHORT_STRING]}
+                            updateStore={false}
                             label={
                                 <FormattedMessage
                                     id={'image-caption-limit-for-min-and-max'}

--- a/src/components/ImagePicker/__snapshots__/ImagePicker.test.js.snap
+++ b/src/components/ImagePicker/__snapshots__/ImagePicker.test.js.snap
@@ -401,6 +401,7 @@ exports[`Image add form ImagePicker component should render view by default 1`] 
               />
             }
             onChange={[Function]}
+            value={null}
           />
           <WithStyles(ForwardRef(Button))
             className="file-upload--external-button"


### PR DESCRIPTION
This pull request fixes issue https://github.com/City-of-Helsinki/linkedevents-ui/issues/537.

The event title disappeared because the image caption field's name attribute used the "name" value and was defined as a HelTextField element. The HelTextField element updates the store on the blur event and because the name of the caption field was "name", it collided with the event's title which is also stored in the store under the "name" key. Thus, the image caption field overrode the event title. Since the event title is an object and the image caption just a string, the event title appeared as an empty field in the UI.

The fix is to replace the HelTextField elements with ordinary TextField elements.