### PR TITLE
Pass missing onSave prop to ImageEdit

### DIFF
--- a/src/components/ImageThumbnail/index.js
+++ b/src/components/ImageThumbnail/index.js
@@ -52,6 +52,7 @@ class ImageThumbnail extends React.PureComponent {
                 thumbnailUrl={this.props.url}
                 license={this.props.data.license}
                 close={() => this.setState({edit: false})}
+                onSave={() => this.setState({edit: false})}
                 updateExisting
             />;
         }


### PR DESCRIPTION
Fix `ImageEdit` crashing by passing the required `onSave` prop.